### PR TITLE
list: fixed flawed logic in `cfl_list_entry_is_orphan`

### DIFF
--- a/include/cfl/cfl_list.h
+++ b/include/cfl/cfl_list.h
@@ -135,8 +135,7 @@ static inline void cfl_list_entry_init(struct cfl_list *entry)
 static inline int cfl_list_entry_is_orphan(struct cfl_list *entry)
 {
     if (entry->next != NULL &&
-        entry->prev != NULL &&
-        entry->next != entry->prev) {
+        entry->prev != NULL) {
         return CFL_FALSE;
     }
 


### PR DESCRIPTION
A list with a single element will have matching `prev` and `next` values 
so I had to remove the second condition.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>