### PR TITLE
list: fix offset calculation on win32.

### DIFF
--- a/include/cfl/cfl_list.h
+++ b/include/cfl/cfl_list.h
@@ -34,7 +34,7 @@
 #ifdef _WIN32
 /* Windows */
 #define cfl_container_of(address, type, field) ((type *)(                   \
-                                                        (unsigned char)(address) - \
+                                                        (unsigned char *)(address) - \
                                                         (intptr_t)(&((type *)0)->field)))
 #else
 /* Rest of the world */


### PR DESCRIPTION
When casting the address to `unsigned char` cfl_list_entry returns a simple two byte value, which causes memory errors.