### PR TITLE
compat: Fix MSYS2 platform build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,35 @@ jobs:
         run: |
           ctest --rerun-failed --output-on-failure -C Debug --test-dir .\tests\
 
+  build-msys2:
+    name: Build sources on MSYS2 for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-2019]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get dependencies w/ chocolatey
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: UCRT64
+          path-type: inherit
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+      - name: Build on ${{ matrix.os }} with MSYS2
+        shell: msys2 {0}
+        run: |
+          cmake -G "MinGW Makefiles" -DCFL_TESTS=On .
+          cmake --build .
+      - name: Run unit tests.
+        run: |
+          ctest --rerun-failed --output-on-failure -C Debug --test-dir .\tests\
+
   build-centos:
     name: CentOS 7 build to confirm no issues once used downstream
     runs-on: ubuntu-latest

--- a/include/cfl/cfl_compat.h
+++ b/include/cfl/cfl_compat.h
@@ -29,14 +29,18 @@
 
 #ifdef CFL_SYSTEM_WINDOWS
 
+#ifdef _MSC_VER
 /*
- * Windows prefer to add an underscore to each POSIX function.
+ * cl.exe that is one of the C++ compilers for Windows prefers
+ * to add an underscore to each POSIX function.
  * To suppress compiler warnings, we need these trivial macros.
+ * For MSYS2 platform on Windows, we don't need to do.
  */
 #define timezone _timezone
 #define tzname _tzname
 #define strncasecmp _strnicmp
 #define timegm _mkgmtime
+#endif /* _MSC_VER */
 
 #endif
 #endif

--- a/src/cfl_variant.c
+++ b/src/cfl_variant.c
@@ -22,6 +22,12 @@
 #include <cfl/cfl_array.h>
 #include <cfl/cfl_kvlist.h>
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define HEXDUMPFORMAT "%#x"
+#else
+#define HEXDUMPFORMAT "%p"
+#endif
+
 int cfl_variant_print(FILE *fp, struct cfl_variant *val)
 {
     int ret = -1;
@@ -58,7 +64,7 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
         break;
 
     case CFL_VARIANT_REFERENCE:
-        ret = fprintf(fp, "%p", val->data.as_reference);
+        ret = fprintf(fp, HEXDUMPFORMAT, val->data.as_reference);
         break;
     case CFL_VARIANT_ARRAY:
         ret = cfl_array_print(fp, val->data.as_array);

--- a/tests/variant.c
+++ b/tests/variant.c
@@ -88,7 +88,9 @@ static void test_variant_print_bool()
         }
 
         ret = cfl_variant_print(fp, val);
-        if (!TEST_CHECK(ret > 0)) {
+        /* Check whether EOF or not. Not checking for positive
+         * number here. */
+        if (!TEST_CHECK(ret != EOF)) {
             TEST_MSG("%d:cfl_variant_print failed", i);
             cfl_variant_destroy(val);
             fclose(fp);
@@ -440,7 +442,7 @@ static void test_variant_print_unknown()
     }
 
     ret = cfl_variant_print(fp, val);
-    if (!TEST_CHECK(ret > 0)) {
+    if (!TEST_CHECK(ret != EOF)) {
         TEST_MSG("cfl_variant_print failed");
         fclose(fp);
         cfl_variant_destroy(val);


### PR DESCRIPTION
To build with MSYS2, we don't need to use these trivial macros on cfl_compat.h.

Otherwise, they cause the following errors:

```log
In file included from C:\Users\cosmo\Documents\GitHub\cfl\src\cfl_time.c:29:
C:/Users/cosmo/Documents/GitHub/cfl/include/cfl/cfl_compat.h:40:16: error: '__tzname' declared as function returning an array
   40 | #define tzname _tzname
      |                ^~~~~~~
C:/Users/cosmo/Documents/GitHub/cfl/include/cfl/cfl_compat.h:40:16: error: conflicting types for '__tzname'; have 'int(
'
C:/Ruby31-x64/msys64/ucrt64/include/time.h:123:26: note: previous declaration of '__tzname' with type 'char **(void)'
  123 |   _CRTIMP char **__cdecl __tzname(void);
      |                          ^~~~~~~~
C:/Users/cosmo/Documents/GitHub/cfl/include/cfl/cfl_compat.h:39:18: error: expected '{' before '(' token
   39 | #define timezone _timezone
      |                  ^~~~~~~~~
C:/Users/cosmo/Documents/GitHub/cfl/include/cfl/cfl_compat.h:39:18: error: expected '{' before '(' token
   39 | #define timezone _timezone
      |                  ^~~~~~~~~
mingw32-make[2]: *** [src\CMakeFiles\cfl-static.dir\build.make:121: src/CMakeFiles/cfl-static.dir/cfl_time.c.obj] Error 1
mingw32-make[1]: *** [CMakeFiles\Makefile2:157: src/CMakeFiles/cfl-static.dir/all] Error 2
```

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>