### PR TITLE
hash: added a missing hash type

### DIFF
--- a/include/cfl/cfl_hash.h
+++ b/include/cfl/cfl_hash.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include "xxh3.h"
 
+#define cfl_hash_64bits_t      XXH64_hash_t
 #define cfl_hash_state_t       XXH3_state_t
 #define cfl_hash_64bits_reset  XXH3_64bits_reset
 #define cfl_hash_64bits_update XXH3_64bits_update


### PR DESCRIPTION
This PR adds a missing hash type required by fluent bit