### PR TITLE
lib/xxhash: do no longer depend on <assert.h> for XXH_STATIC_ASSERT

### DIFF
--- a/lib/xxhash/xxhash.h
+++ b/lib/xxhash/xxhash.h
@@ -1546,8 +1546,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 /* note: use after variable declarations */
 #ifndef XXH_STATIC_ASSERT
 #  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
-#    include <assert.h>
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { _Static_assert((c),m); } while(0)
 #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
 #    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
 #  else


### PR DESCRIPTION
Use `_Static_assert`, which is part of the C11 language.

  - upstream: https://github.com/Cyan4973/xxHash/commit/6189ecd3d44a693460f86280ccf49d33cb4b18e1
  - fixes: https://github.com/buildroot/buildroot/commit/d649bcd3805a26cedb30120ebbdcf12f8fbf449f
  - It has been a while since the last xxHash release, so just cherry-pick this locally.