### PR TITLE
variant: support uint64_t

### DIFF
--- a/include/cfl/cfl_array.h
+++ b/include/cfl/cfl_array.h
@@ -52,6 +52,7 @@ int cfl_array_append_bytes(struct cfl_array *array, char *value, size_t length);
 int cfl_array_append_reference(struct cfl_array *array, void *value);
 int cfl_array_append_bool(struct cfl_array *array, int value);
 int cfl_array_append_int64(struct cfl_array *array, int64_t value);
+int cfl_array_append_uint64(struct cfl_array *array, uint64_t value);
 int cfl_array_append_double(struct cfl_array *array, double value);
 int cfl_array_append_array(struct cfl_array *array, struct cfl_array *value);
 int cfl_array_append_new_array(struct cfl_array *array, size_t size);

--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -54,6 +54,9 @@ int cfl_kvlist_insert_bool(struct cfl_kvlist *list,
 int cfl_kvlist_insert_int64(struct cfl_kvlist *list,
                             char *key, int64_t value);
 
+int cfl_kvlist_insert_uint64(struct cfl_kvlist *list,
+                            char *key, uint64_t value);
+
 int cfl_kvlist_insert_double(struct cfl_kvlist *list,
                              char *key, double value);
 

--- a/include/cfl/cfl_variant.h
+++ b/include/cfl/cfl_variant.h
@@ -31,6 +31,7 @@
 #define CFL_VARIANT_KVLIST    6
 #define CFL_VARIANT_BYTES     7
 #define CFL_VARIANT_REFERENCE 8
+#define CFL_VARIANT_UINT      9
 
 struct cfl_array;
 struct cfl_kvlist;
@@ -43,6 +44,7 @@ struct cfl_variant {
         cfl_sds_t as_bytes;
         unsigned int as_bool;
         int64_t as_int64;
+        uint64_t as_uint64;
         double as_double;
         void *as_reference;
         struct cfl_array *as_array;
@@ -54,6 +56,7 @@ struct cfl_variant *cfl_variant_create_from_string(char *value);
 struct cfl_variant *cfl_variant_create_from_bytes(char *value, size_t length);
 struct cfl_variant *cfl_variant_create_from_bool(int value);
 struct cfl_variant *cfl_variant_create_from_int64(int64_t value);
+struct cfl_variant *cfl_variant_create_from_uint64(uint64_t value);
 struct cfl_variant *cfl_variant_create_from_double(double value);
 struct cfl_variant *cfl_variant_create_from_array(struct cfl_array *value);
 struct cfl_variant *cfl_variant_create_from_kvlist(struct cfl_kvlist *value);

--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -261,6 +261,27 @@ int cfl_array_append_int64(struct cfl_array *array, int64_t value)
     return 0;
 }
 
+int cfl_array_append_uint64(struct cfl_array *array, uint64_t value)
+{
+    struct cfl_variant *value_instance;
+    int                 result;
+
+    value_instance = cfl_variant_create_from_uint64(value);
+
+    if (value_instance == NULL) {
+        return -1;
+    }
+
+    result = cfl_array_append(array, value_instance);
+
+    if (result) {
+        cfl_variant_destroy(value_instance);
+        return -2;
+    }
+
+    return 0;
+}
+
 
 int cfl_array_append_double(struct cfl_array *array, double value)
 {

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -212,6 +212,29 @@ int cfl_kvlist_insert_int64(struct cfl_kvlist *list,
     return 0;
 }
 
+int cfl_kvlist_insert_uint64(struct cfl_kvlist *list,
+                            char *key, uint64_t value)
+{
+    struct cfl_variant *value_instance;
+    int                 result;
+
+    value_instance = cfl_variant_create_from_uint64(value);
+
+    if (value_instance == NULL) {
+        return -1;
+    }
+
+    result = cfl_kvlist_insert(list, key, value_instance);
+
+    if (result) {
+        cfl_variant_destroy(value_instance);
+
+        return -2;
+    }
+
+    return 0;
+}
+
 int cfl_kvlist_insert_double(struct cfl_kvlist *list,
                              char *key, double value)
 {

--- a/src/cfl_variant.c
+++ b/src/cfl_variant.c
@@ -53,6 +53,9 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
     case CFL_VARIANT_INT:
         ret = fprintf(fp, "%" PRId64, val->data.as_int64);
         break;
+    case CFL_VARIANT_UINT:
+        ret = fprintf(fp, "%" PRIu64, val->data.as_uint64);
+        break;
     case CFL_VARIANT_DOUBLE:
         ret = fprintf(fp, "%lf", val->data.as_double);
         break;
@@ -141,6 +144,19 @@ struct cfl_variant *cfl_variant_create_from_int64(int64_t value)
     if (instance != NULL) {
         instance->data.as_int64 = value;
         instance->type = CFL_VARIANT_INT;
+    }
+
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_uint64(uint64_t value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create();
+    if (instance != NULL) {
+        instance->data.as_uint64 = value;
+        instance->type = CFL_VARIANT_UINT;
     }
 
     return instance;

--- a/tests/variant.c
+++ b/tests/variant.c
@@ -144,6 +144,45 @@ static void test_variant_print_int64()
     }
 }
 
+static void test_variant_print_uint64()
+{
+    int ret;
+    int i;
+    uint64_t inputs[] = {1, 0, 18446744073709551615ULL};
+    char *expects[] = {"1", "0", "18446744073709551615" /*UINT64_MAX*/};
+
+    FILE *fp = NULL;
+    struct cfl_variant *val = NULL;
+
+    for (i=0; i<sizeof(inputs)/sizeof(uint64_t); i++) {
+        fp = tmpfile();
+        if (!TEST_CHECK(fp != NULL)) {
+            TEST_MSG("%d: fp is NULL", i);
+            continue;
+        }
+        val = cfl_variant_create_from_uint64(inputs[i]);
+        if (!TEST_CHECK(val != NULL)) {
+            TEST_MSG("%d: cfl_variant_create_from_uint64 failed", i);
+            fclose(fp);
+            continue;
+        }
+
+        ret = cfl_variant_print(fp, val);
+        if (!TEST_CHECK(ret > 0)) {
+            TEST_MSG("%d:cfl_variant_print failed", i);
+            cfl_variant_destroy(val);
+            fclose(fp);
+            continue;
+        }
+        ret = compare(fp, expects[i], 0);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("%d:compare failed", i);
+        }
+        cfl_variant_destroy(val);
+        fclose(fp);
+    }
+}
+
 static void test_variant_print_array()
 {
     int ret;
@@ -459,6 +498,7 @@ static void test_variant_print_unknown()
 TEST_LIST = {
     {"variant_print_bool", test_variant_print_bool},
     {"variant_print_int64", test_variant_print_int64},
+    {"variant_print_uint64", test_variant_print_uint64},
     {"variant_print_double", test_variant_print_double},
     {"variant_print_string", test_variant_print_string},
     {"variant_print_bytes", test_variant_print_bytes},


### PR DESCRIPTION
This patch is to support uint64_t for cfl_variant/array/kvlist and test code.