### PR TITLE
cfl_array: fix memory overlap when removing from array by index.

### DIFF
--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -88,9 +88,9 @@ int cfl_array_remove_by_index(struct cfl_array *array,
     cfl_variant_destroy(array->entries[position]);
 
     if (position != array->entry_count - 1) {
-        memcpy(&array->entries[position],
-               &array->entries[position + 1],
-               sizeof(void *) * (array->entry_count - (position + 1)));
+        memmove(&array->entries[position],
+                &array->entries[position + 1],
+                sizeof(void *) * (array->entry_count - (position + 1)));
     }
     else {
         array->entries[position] = NULL;


### PR DESCRIPTION
This code will fail, at the very least when using ASAn:

```c
    cfl_variant_destroy(array->entries[position]);

    if (position != array->entry_count - 1) {
        memcpy(&array->entries[position],
               &array->entries[position + 1],
               sizeof(void *) * (array->entry_count - (position + 1)));
    }
    else {
        array->entries[position] = NULL;
```

This is because you will inevitably be copying over the remaining values on top of the value being removed.

This fix just replaces memcpy for memmove which allows for src and dst to overlap.
