### PR TITLE
compat: utils: Use <sys/types.h> to define off_t

### DIFF
--- a/include/cfl/cfl_compat.h
+++ b/include/cfl/cfl_compat.h
@@ -41,7 +41,6 @@
 #define strncasecmp _strnicmp
 #define strcasecmp _stricmp
 #define timegm _mkgmtime
-typedef __int64 off_t;
 #endif /* _MSC_VER */
 
 #endif

--- a/include/cfl/cfl_utils.h
+++ b/include/cfl/cfl_utils.h
@@ -1,6 +1,7 @@
 #ifndef CFL_UTILS_H
 #define CFL_UTILS_H
 
+#include <sys/types.h> /* off_t */
 #include <cfl/cfl_sds.h>
 #include <cfl/cfl_compat.h>
 


### PR DESCRIPTION
In MSVC, off_t is defined in <sys/types.h>.
We don't need to define our own definition for off_t.