### PR TITLE
kvlist: Handle referenced condition on teardown

### DIFF
--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -508,11 +508,10 @@ void cfl_kvpair_destroy(struct cfl_kvpair *pair)
             cfl_sds_destroy(pair->key);
         }
 
-        if (pair->val != NULL) {
+        if (pair->val != NULL && !pair->val->referenced) {
             cfl_variant_destroy(pair->val);
         }
 
         free(pair);
     }
 }
-

--- a/tests/kvlist.c
+++ b/tests/kvlist.c
@@ -1065,7 +1065,7 @@ static void test_basics()
     ret = cfl_kvlist_insert_string(list, "key1", "value1");
     TEST_CHECK(ret == 0);
 
-    ret = cfl_kvlist_insert_bytes(list, "key2", "value2", 6, CFL_TRUE);
+    ret = cfl_kvlist_insert_bytes(list, "key2", "value2", 6, CFL_FALSE);
     TEST_CHECK(ret == 0);
 
     ret = cfl_kvlist_insert_reference(list, "key3", (void *) 0xdeadbeef);


### PR DESCRIPTION
In some of the conditions, `kvpair->val` is not allocated and just as a reference.
`cfl_kvlist_insert_string_s()` is able to create referenced string value on kvlists.