### PR TITLE
kvlist: provide options for case sensitivity fetch

### DIFF
--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -31,6 +31,11 @@
 struct cfl_array;
 struct cfl_arena;
 
+enum cfl_kvlist_match_mode {
+    CFL_KVLIST_MATCH_CASE_INSENSITIVE = 0,
+    CFL_KVLIST_MATCH_CASE_SENSITIVE
+};
+
 struct cfl_kvpair {
     cfl_sds_t            key;    /* Key */
     struct cfl_variant   *val;   /* Value */
@@ -143,11 +148,24 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
                         char *key, size_t key_size,
                         struct cfl_variant *value);
 
-struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_t key_size);
-struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list, char *key, size_t key_size);
+struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list,
+                                       char *key, size_t key_size);
+/* The existing fetch, contains, and remove APIs match case-insensitively. */
+struct cfl_variant *cfl_kvlist_fetch_ex(struct cfl_kvlist *list,
+                                        char *key,
+                                        enum cfl_kvlist_match_mode mode);
+struct cfl_variant *cfl_kvlist_fetch_s_ex(struct cfl_kvlist *list,
+                                          char *key, size_t key_size,
+                                          enum cfl_kvlist_match_mode mode);
+struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list,
+                                            char *key, size_t key_size);
 
 int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name);
+int cfl_kvlist_contains_ex(struct cfl_kvlist *kvlist, char *name,
+                           enum cfl_kvlist_match_mode mode);
 int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name);
+int cfl_kvlist_remove_ex(struct cfl_kvlist *kvlist, char *name,
+                         enum cfl_kvlist_match_mode mode);
 void cfl_kvpair_destroy(struct cfl_kvpair *pair);
 struct cfl_variant *cfl_kvpair_take_value(struct cfl_kvpair *pair);
 int cfl_kvpair_key_set_s(struct cfl_kvpair *pair,

--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -144,6 +144,7 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
                         struct cfl_variant *value);
 
 struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_t key_size);
+struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list, char *key, size_t key_size);
 
 int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name);
 int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name);

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -24,6 +24,7 @@
 #include "cfl_arena_internal.h"
 #include <cfl/cfl_compat.h>
 
+#include <ctype.h>
 #include <limits.h>
 
 #include <cfl/cfl_container.h>
@@ -494,7 +495,36 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
     return 0;
 }
 
-struct cfl_variant *cfl_kvlist_fetch_internal_s(struct cfl_kvlist *list, char *key, size_t key_size, int case_sensitive)
+static int key_matches(cfl_sds_t candidate, char *key, size_t key_size,
+                       enum cfl_kvlist_match_mode mode)
+{
+    size_t index;
+
+    if (cfl_sds_len(candidate) != key_size) {
+        return CFL_FALSE;
+    }
+
+    if (mode == CFL_KVLIST_MATCH_CASE_SENSITIVE) {
+        return memcmp(candidate, key, key_size) == 0;
+    }
+
+    if (mode == CFL_KVLIST_MATCH_CASE_INSENSITIVE) {
+        for (index = 0; index < key_size; index++) {
+            if (tolower((unsigned char) candidate[index]) !=
+                tolower((unsigned char) key[index])) {
+                return CFL_FALSE;
+            }
+        }
+
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+struct cfl_variant *cfl_kvlist_fetch_s_ex(
+    struct cfl_kvlist *list, char *key, size_t key_size,
+    enum cfl_kvlist_match_mode mode)
 {
     struct cfl_list *head;
     struct cfl_kvpair *pair;
@@ -506,31 +536,26 @@ struct cfl_variant *cfl_kvlist_fetch_internal_s(struct cfl_kvlist *list, char *k
     cfl_list_foreach(head, &list->list) {
         pair = cfl_list_entry(head, struct cfl_kvpair, _head);
 
-        if (cfl_sds_len(pair->key) != key_size) {
-            continue;
-        }
-
-        if (case_sensitive == CFL_TRUE ) {
-            if (strncmp(pair->key, key, key_size) == 0) {
-                return pair->val;
-            }
-        } else {
-            if (strncasecmp(pair->key, key, key_size) == 0) {
-                return pair->val;
-            }
+        if (key_matches(pair->key, key, key_size, mode) == CFL_TRUE) {
+            return pair->val;
         }
     }
 
     return NULL;
 }
 
-struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_t key_size) {
-    return cfl_kvlist_fetch_internal_s(list, key, key_size, CFL_FALSE);
+struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list,
+                                       char *key, size_t key_size)
+{
+    return cfl_kvlist_fetch_s_ex(list, key, key_size,
+                                 CFL_KVLIST_MATCH_CASE_INSENSITIVE);
 }
 
-struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list, char *key, size_t key_size)
+struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list,
+                                            char *key, size_t key_size)
 {
-    return cfl_kvlist_fetch_internal_s(list, key, key_size, CFL_TRUE);
+    return cfl_kvlist_fetch_s_ex(list, key, key_size,
+                                 CFL_KVLIST_MATCH_CASE_SENSITIVE);
 }
 
 int cfl_kvlist_insert_string(struct cfl_kvlist *list,
@@ -655,11 +680,19 @@ int cfl_kvlist_insert(struct cfl_kvlist *list,
 
 struct cfl_variant *cfl_kvlist_fetch(struct cfl_kvlist *list, char *key)
 {
-    if (!list || !key) {
+    return cfl_kvlist_fetch_ex(list, key,
+                               CFL_KVLIST_MATCH_CASE_INSENSITIVE);
+}
+
+struct cfl_variant *cfl_kvlist_fetch_ex(
+    struct cfl_kvlist *list, char *key,
+    enum cfl_kvlist_match_mode mode)
+{
+    if (list == NULL || key == NULL) {
         return NULL;
     }
 
-    return cfl_kvlist_fetch_s(list, key, strlen(key));
+    return cfl_kvlist_fetch_s_ex(list, key, strlen(key), mode);
 }
 
 int cfl_kvlist_count(struct cfl_kvlist *list)
@@ -728,10 +761,16 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
 
 int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name)
 {
+    return cfl_kvlist_contains_ex(kvlist, name,
+                                  CFL_KVLIST_MATCH_CASE_INSENSITIVE);
+}
+
+int cfl_kvlist_contains_ex(struct cfl_kvlist *kvlist, char *name,
+                           enum cfl_kvlist_match_mode mode)
+{
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
     size_t             name_len;
-    size_t             key_len;
 
     if (kvlist == NULL || name == NULL) {
         return CFL_FALSE;
@@ -743,12 +782,7 @@ int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name)
         pair = cfl_list_entry(iterator,
                               struct cfl_kvpair, _head);
 
-        key_len = cfl_sds_len(pair->key);
-        if (key_len != name_len) {
-            continue;
-        }
-
-        if (strncasecmp(pair->key, name, name_len) == 0) {
+        if (key_matches(pair->key, name, name_len, mode) == CFL_TRUE) {
             return CFL_TRUE;
         }
     }
@@ -759,11 +793,17 @@ int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name)
 
 int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name)
 {
+    return cfl_kvlist_remove_ex(kvlist, name,
+                                CFL_KVLIST_MATCH_CASE_INSENSITIVE);
+}
+
+int cfl_kvlist_remove_ex(struct cfl_kvlist *kvlist, char *name,
+                         enum cfl_kvlist_match_mode mode)
+{
     struct cfl_list   *iterator_backup;
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
     size_t             name_len;
-    size_t             key_len;
     int                removed;
 
     if (kvlist == NULL || name == NULL) {
@@ -777,12 +817,7 @@ int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name)
         pair = cfl_list_entry(iterator,
                               struct cfl_kvpair, _head);
 
-        key_len = cfl_sds_len(pair->key);
-        if (key_len != name_len) {
-            continue;
-        }
-
-        if (strncasecmp(pair->key, name, name_len) == 0) {
+        if (key_matches(pair->key, name, name_len, mode) == CFL_TRUE) {
             cfl_kvpair_destroy(pair);
             removed = CFL_TRUE;
         }

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -494,7 +494,7 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
     return 0;
 }
 
-struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_t key_size)
+struct cfl_variant *cfl_kvlist_fetch_internal_s(struct cfl_kvlist *list, char *key, size_t key_size, int case_sensitive)
 {
     struct cfl_list *head;
     struct cfl_kvpair *pair;
@@ -510,14 +510,28 @@ struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_
             continue;
         }
 
-        if (strncasecmp(pair->key, key, key_size) == 0) {
-            return pair->val;
+        if (case_sensitive == CFL_TRUE ) {
+            if (strncmp(pair->key, key, key_size) == 0) {
+                return pair->val;
+            }
+        } else {
+            if (strncasecmp(pair->key, key, key_size) == 0) {
+                return pair->val;
+            }
         }
     }
 
     return NULL;
 }
 
+struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_t key_size) {
+    return cfl_kvlist_fetch_internal_s(list, key, key_size, CFL_FALSE);
+}
+
+struct cfl_variant *cfl_kvlist_fetch_case_s(struct cfl_kvlist *list, char *key, size_t key_size)
+{
+    return cfl_kvlist_fetch_internal_s(list, key, key_size, CFL_TRUE);
+}
 
 int cfl_kvlist_insert_string(struct cfl_kvlist *list,
                              char *key, char *value)

--- a/tests/kvlist.c
+++ b/tests/kvlist.c
@@ -1323,6 +1323,115 @@ static void embedded_nul_keys_do_not_match_short_name()
     cfl_kvlist_destroy(list);
 }
 
+static void case_sensitive_operations()
+{
+    int ret;
+    char upper_key[] = {'U', 's', 'e', 'r'};
+    char lower_key[] = {'u', 's', 'e', 'r'};
+    char nul_key[] = {'k', '\0', 'A'};
+    char different_nul_key[] = {'K', '\0', 'B'};
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_int64(list, "User", 1);
+    TEST_CHECK(ret == 0);
+    ret = cfl_kvlist_insert_int64(list, "user", 2);
+    TEST_CHECK(ret == 0);
+    ret = cfl_kvlist_insert_int64_s(list, nul_key, sizeof(nul_key), 3);
+    TEST_CHECK(ret == 0);
+
+    variant = cfl_kvlist_fetch_s_ex(list, upper_key, sizeof(upper_key),
+                                    CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(variant != NULL);
+    TEST_CHECK(variant->data.as_int64 == 1);
+
+    variant = cfl_kvlist_fetch_case_s(list, lower_key, sizeof(lower_key));
+    TEST_CHECK(variant != NULL);
+    TEST_CHECK(variant->data.as_int64 == 2);
+
+    variant = cfl_kvlist_fetch_ex(list, "USER",
+                                  CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(variant == NULL);
+    variant = cfl_kvlist_fetch(list, "USER");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_kvlist_contains_ex(list, "USER",
+                                 CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(ret == CFL_FALSE);
+    ret = cfl_kvlist_contains(list, "USER");
+    TEST_CHECK(ret == CFL_TRUE);
+
+    ret = cfl_kvlist_remove_ex(list, "User",
+                               CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(ret == CFL_TRUE);
+    TEST_CHECK(cfl_kvlist_count(list) == 2);
+    TEST_CHECK(cfl_kvlist_fetch_ex(list, "User",
+                                  CFL_KVLIST_MATCH_CASE_SENSITIVE) == NULL);
+    variant = cfl_kvlist_fetch_ex(list, "user",
+                                  CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(variant != NULL);
+    TEST_CHECK(variant->data.as_int64 == 2);
+
+    variant = cfl_kvlist_fetch_s_ex(list, different_nul_key,
+                                    sizeof(different_nul_key),
+                                    CFL_KVLIST_MATCH_CASE_INSENSITIVE);
+    TEST_CHECK(variant == NULL);
+    variant = cfl_kvlist_fetch_s_ex(list, nul_key, sizeof(nul_key),
+                                    CFL_KVLIST_MATCH_CASE_INSENSITIVE);
+    TEST_CHECK(variant != NULL);
+    TEST_CHECK(variant->data.as_int64 == 3);
+
+    variant = cfl_kvlist_fetch_ex(list, "user",
+                                  (enum cfl_kvlist_match_mode) 99);
+    TEST_CHECK(variant == NULL);
+    ret = cfl_kvlist_contains_ex(list, "user",
+                                 (enum cfl_kvlist_match_mode) 99);
+    TEST_CHECK(ret == CFL_FALSE);
+    ret = cfl_kvlist_remove_ex(list, "user",
+                               (enum cfl_kvlist_match_mode) 99);
+    TEST_CHECK(ret == CFL_FALSE);
+    TEST_CHECK(cfl_kvlist_count(list) == 2);
+
+    cfl_kvlist_destroy(list);
+}
+
+static void case_sensitive_arena_operations()
+{
+    int ret;
+    struct cfl_arena *arena;
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    arena = cfl_arena_create(256);
+    TEST_CHECK(arena != NULL);
+    list = cfl_kvlist_create_in(arena);
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, "TraceId", "upper");
+    TEST_CHECK(ret == 0);
+    ret = cfl_kvlist_insert_string(list, "traceid", "lower");
+    TEST_CHECK(ret == 0);
+
+    variant = cfl_kvlist_fetch_ex(list, "TraceId",
+                                  CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(variant != NULL);
+    TEST_CHECK(strcmp(variant->data.as_string, "upper") == 0);
+
+    ret = cfl_kvlist_remove_ex(list, "traceid",
+                               CFL_KVLIST_MATCH_CASE_SENSITIVE);
+    TEST_CHECK(ret == CFL_TRUE);
+    TEST_CHECK(cfl_kvlist_count(list) == 1);
+    TEST_CHECK(cfl_kvlist_contains_ex(list, "TraceId",
+                                     CFL_KVLIST_MATCH_CASE_SENSITIVE) ==
+               CFL_TRUE);
+
+    cfl_kvlist_destroy(list);
+    cfl_arena_destroy(arena);
+}
+
 static void print_write_error()
 {
 #ifdef __linux__
@@ -1542,6 +1651,8 @@ TEST_LIST = {
     {"null_inputs", null_inputs},
     {"print_escaped_keys", print_escaped_keys},
     {"embedded_nul_keys_do_not_match_short_name", embedded_nul_keys_do_not_match_short_name},
+    {"case_sensitive_operations", case_sensitive_operations},
+    {"case_sensitive_arena_operations", case_sensitive_arena_operations},
     {"print_write_error", print_write_error},
     {"reject_kvlist_cycles", reject_kvlist_cycles},
     {"reject_variant_cycles", reject_variant_cycles},


### PR DESCRIPTION
Added internal function that handles optional case-sensitivity check, provided new public function to invoke it with case-sensitive option with default from #55 being case-insensitive.