### PR TITLE
Do not export internal sds_alloc function

### DIFF
--- a/include/cfl/cfl_sds.h
+++ b/include/cfl/cfl_sds.h
@@ -49,7 +49,6 @@ static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
 }
 
 size_t cfl_sds_avail(cfl_sds_t s);
-cfl_sds_t sds_alloc(size_t size);
 size_t cfl_sds_alloc(cfl_sds_t s);
 cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len);
 size_t cfl_sds_len(cfl_sds_t s);

--- a/src/cfl_sds.c
+++ b/src/cfl_sds.c
@@ -38,7 +38,7 @@ size_t cfl_sds_avail(cfl_sds_t s)
     return (size_t) (h->alloc - h->len);
 }
 
-cfl_sds_t sds_alloc(size_t size)
+static cfl_sds_t sds_alloc(size_t size)
 {
     void *buf;
     cfl_sds_t s;


### PR DESCRIPTION
This removes `sds_alloc` from the cfl headers. This is an internal function and also clashes with sds library.