### PR TITLE
core: add CFL atomics and API hardening

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-latest, windows-2022]
     steps:
       - uses: actions/checkout@v6
-      - name: Build on ${{ matrix.os }} with vs-2019
+      - name: Build on ${{ matrix.os }} with MSVC
         run: |
           .\scripts\win_build.bat
       - name: Run unit tests.
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-latest, windows-2022]
     steps:
       - uses: actions/checkout@v6
       - name: Get dependencies w/ chocolatey
@@ -200,33 +200,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          dependencies_debian: 'wget'
 
-      - name: Install CMake 3.20.0
-        run: |
-          CMAKE_VERSION=3.20.0
-          wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh
-          chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh
-
-          # Create a writable temporary directory
-          mkdir -p /tmp/cmake
-
-          # Install CMake to /tmp/cmake
-          ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/tmp/cmake
-
-          # Add CMake to the PATH
-          echo 'export PATH=/tmp/cmake/bin:$PATH' >> ~/.bashrc
-          source ~/.bashrc
-
-          # Verify installation
-          /tmp/cmake/bin/cmake --version
-
-      - uses: actions/checkout@v6
+      - uses: docker://lpenz/ghaction-cmake:0.19
         with:
+          pre_command: |
+            CMAKE_VERSION=3.20.0
+            curl -fsSLO https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh
+            chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh
+            ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/usr/local
+            cmake --version
           preset: ${{ matrix.preset }}
-
           cmakeflags: '-DCFL_TESTS=On -DCFL_DEV=on .'
-          build_command: /tmp/cmake/bin/cmake && make all
+          build_command: make all
 
   # this job provides the single required status for PRs to be merged into main.
   # instead of updating the protected branch status in github, developers can update the needs section below

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,7 +106,11 @@ jobs:
     steps:
       - name: Set up base image dependencies
         run: |
-          apt-get update
+          printf '%s\n' \
+            'deb http://archive.debian.org/debian buster main' \
+            'deb http://archive.debian.org/debian-security buster/updates main' \
+            > /etc/apt/sources.list
+          apt-get -o Acquire::Check-Valid-Until=false update
           apt-get install -y build-essential wget make gcc g++
 
       - name: Install CMake 3.20.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Repository Guidelines
+
+## Preferred Commands
+- Configure with tests: `cmake -S . -B build -DCFL_TESTS=On`
+- Build: `cmake --build build -j8`
+- Run all tests: `ctest --test-dir build --output-on-failure`
+- Run a focused test: `ctest --test-dir build -R <name> --output-on-failure`
+- Check staged or local patches for whitespace before closing a change:
+  `git diff --check`
+
+## Project Structure & Module Organization
+CFL is a small C library built with CMake.
+
+- `include/cfl/`: public CFL headers.
+- `src/`: library implementation files.
+- `tests/`: acutest-based unit tests.
+- `lib/xxhash/`: bundled xxHash dependency.
+- `cmake/`: project CMake helpers.
+
+Keep changes scoped to the affected module. Put public declarations in
+`include/cfl/`, implementation in `src/`, and matching unit coverage in
+`tests/` when behavior changes.
+
+## Build, Test, and Development Commands
+- `cmake -S . -B build -DCFL_TESTS=On`: configure the project with tests.
+- `cmake --build build -j8`: compile the static library and tests.
+- `ctest --test-dir build --output-on-failure`: run the enabled test suite.
+- `ctest --test-dir build -R cfl-test-<name> --output-on-failure`: run a
+  focused unit test.
+
+Prefer targeted test runs while iterating, then run the full enabled suite
+before closing changes that touch shared code or public APIs.
+
+## Coding Style & Naming Conventions
+- Follow the existing Apache-style C conventions used in this repository.
+- Use 4-space indentation and keep lines readable; avoid unnecessary wrapping.
+- Always use braces for `if/else/while/do` blocks.
+- Put function opening braces on the next line:
+  `int fn(void)\n{ ... }`
+- Declare variables at the start of functions, not mid-block.
+- Prefer descriptive `snake_case` names with the `cfl_` prefix for public APIs.
+- Use `CFL_TRUE` and `CFL_FALSE` for CFL boolean-style return values.
+- Use `/* ... */` comments, and add comments only where they clarify non-obvious
+  behavior.
+- Keep public headers self-contained by including the standard headers they need.
+
+## Testing Guidelines
+- Add or update acutest unit coverage for behavior changes.
+- Keep tests close to the affected module and name test binaries through
+  `tests/CMakeLists.txt`.
+- Validate both success and failure paths for parsers, containers, allocation
+  handling, and boundary conditions.
+- Run broader coverage when changing shared headers, CMake wiring, memory
+  ownership, or common data structures.
+- If a relevant test cannot be run, report the exact blocker in the final
+  response.
+
+## Commit & Pull Request Guidelines
+- Follow observed local history style:
+  `component: short imperative description`
+  Examples: `sds: do not export internal sds_alloc function`,
+  `build: bump to v0.6.2`, `atomic: add atomic operations API`.
+- Keep each commit scoped to one component or interface.
+- Keep subject/body lines concise; use a body when the reason or scope is not
+  obvious from the subject.
+- Do not mix unrelated code and documentation updates in one commit unless the
+  user explicitly asks for a combined commit.
+- Do not rewrite history, amend commits, create remote branches, or open pull
+  requests unless explicitly requested.
+
+## Agent Action Limits
+- Do not modify repositories or files outside this project unless the user
+  explicitly asks.
+- Do not revert user changes outside the requested scope.
+- Preserve unrelated untracked or modified files in the worktree.
+- Prefer minimal patches that avoid unrelated formatting or refactoring churn.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,71 @@
 # CFL
 
-CFL is a tiny library that provides interfaces for data structures, originally created to satisfy the needs of Fluent Bit and other libraries used internally like CMetrics and CTraces projects.
+CFL is a tiny C library that provides small data-structure and utility
+interfaces. It was originally created to satisfy the needs of Fluent Bit and
+related libraries such as CMetrics and CTraces.
 
-note: The name doesn't mean anything specific, you can call it `c:\ floppy` if you want.
+Note: The name does not mean anything specific; you can call it `c:\ floppy`
+if you want.
 
 ## Interfaces
 
-- cfl_sds: string manipulation
-- cfl_list: linked list 
-- cfl_kv: key value pairs by using a linked list (cfl_list)
-- cfl_array: array of elements
-- cfl_variant: interface to manage contexts with vairant types
-- cfl_time: time utilities
-- cfl_hash: 64bit hashing functions
+Applications can include `<cfl/cfl.h>` to pull in the common CFL interfaces.
+Specialized headers are also available under `include/cfl/` when a caller only
+needs one module.
+
+### Core
+
+- `cfl_init()`: initializes library-level facilities.
+- `cfl_version()`: returns the CFL version string.
+- `CFL_TRUE` and `CFL_FALSE`: common boolean-style constants used by CFL APIs.
+
+### Data Structures
+
+- `cfl_sds`: dynamic string storage with explicit length and allocation
+  tracking. It supports creation from strings or buffers, growth, concatenation,
+  formatted writes, length updates, and destruction.
+- `cfl_list`: intrusive doubly linked list helpers. It provides initialization,
+  add, append, prepend, delete, concatenate, size, entry lookup, and safe
+  iteration macros.
+- `cfl_kv`: SDS-backed string key/value entries stored in a `cfl_list`. This is
+  useful for simple string maps where values are plain strings.
+- `cfl_variant`: tagged value container for bool, signed integer, unsigned
+  integer, double, null, reference, string, bytes, array, and key/value list
+  values.
+- `cfl_array`: ordered collection of `cfl_variant` entries. It supports fixed
+  or resizable arrays, append helpers for all variant types, fetch by index,
+  removal, size inspection, and printing.
+- `cfl_kvlist`: string-keyed map whose values are `cfl_variant` instances. It
+  supports typed insert helpers, size-aware key APIs, fetch, contains, remove,
+  count, and printing.
+- `cfl_object`: generic wrapper that can hold a `cfl_kvlist`, `cfl_variant`, or
+  `cfl_array` and print the associated value.
+
+### Utilities
+
+- `cfl_atomic`: 64-bit atomic initialization, compare-exchange, store, and load
+  operations with platform-specific backends.
+- `cfl_time`: wall-clock timestamp helper that returns nanoseconds.
+- `cfl_hash`: naming wrappers around xxHash 64-bit and 128-bit hashing APIs.
+- `cfl_checksum`: CRC32C checksum helper.
+- `cfl_utils`: string split helpers, including quote-aware splitting, with
+  results returned as `cfl_list` entries.
+- `cfl_log`: runtime error reporting helpers.
+
+### Support Headers
+
+- `cfl_compat`: platform compatibility macros.
+- `cfl_found`: lightweight include-probe helper for parent projects.
+- `cfl_info`: generated build information and feature flags.
+- `cfl_version`: version macros.
+
+## Build and Test
+
+```sh
+cmake -S . -B build -DCFL_TESTS=On
+cmake --build build -j8
+ctest --test-dir build --output-on-failure
+```
 
 ## License
 

--- a/include/cfl/cfl.h
+++ b/include/cfl/cfl.h
@@ -35,6 +35,7 @@
 #include <cfl/cfl_array.h>
 #include <cfl/cfl_kv.h>
 #include <cfl/cfl_kvlist.h>
+#include <cfl/cfl_checksum.h>
 #include <cfl/cfl_time.h>
 #include <cfl/cfl_variant.h>
 #include <cfl/cfl_object.h>

--- a/include/cfl/cfl_array.h
+++ b/include/cfl/cfl_array.h
@@ -61,6 +61,11 @@ static inline size_t cfl_array_size(struct cfl_array *array)
     return array->entry_count;
 }
 
+/*
+ * Append APIs take ownership of the value on success. A variant, array, or
+ * kvlist must have a single owning parent; inserting the same pointer into
+ * multiple containers is unsupported and can result in double-free.
+ */
 int cfl_array_append(struct cfl_array *array, struct cfl_variant *value);
 int cfl_array_append_string(struct cfl_array *array, char *value);
 int cfl_array_append_string_s(struct cfl_array *array, char *str, size_t str_len, int referenced);

--- a/include/cfl/cfl_array.h
+++ b/include/cfl/cfl_array.h
@@ -21,7 +21,12 @@
 #define CFL_ARRAY_H
 
 #include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <cfl/cfl_variant.h>
+
+struct cfl_kvlist;
 
 struct cfl_array {
     int                  resizable;
@@ -36,6 +41,10 @@ void cfl_array_destroy(struct cfl_array *array);
 static inline struct cfl_variant *cfl_array_fetch_by_index(struct cfl_array *array,
                                                            size_t position)
 {
+    if (array == NULL) {
+        return NULL;
+    }
+
     if (position >= array->entry_count) {
         return NULL;
     }
@@ -45,6 +54,10 @@ static inline struct cfl_variant *cfl_array_fetch_by_index(struct cfl_array *arr
 
 static inline size_t cfl_array_size(struct cfl_array *array)
 {
+    if (array == NULL) {
+        return 0;
+    }
+
     return array->entry_count;
 }
 

--- a/include/cfl/cfl_atomic.h
+++ b/include/cfl/cfl_atomic.h
@@ -17,30 +17,15 @@
  *  limitations under the License.
  */
 
-#ifndef CFL_H
-#define CFL_H
+#ifndef CFL_ATOMIC_H
+#define CFL_ATOMIC_H
 
-#define CFL_FALSE   0
-#define CFL_TRUE    !CFL_FALSE
+#include <stdint.h>
 
-/* headers that are needed in general */
-#include <cfl/cfl_info.h>
-#include <cfl/cfl_version.h>
-#include <cfl/cfl_compat.h>
-#include <cfl/cfl_atomic.h>
-#include <cfl/cfl_log.h>
-#include <cfl/cfl_sds.h>
-#include <cfl/cfl_list.h>
-#include <cfl/cfl_hash.h>
-#include <cfl/cfl_array.h>
-#include <cfl/cfl_kv.h>
-#include <cfl/cfl_kvlist.h>
-#include <cfl/cfl_time.h>
-#include <cfl/cfl_variant.h>
-#include <cfl/cfl_object.h>
-#include <cfl/cfl_utils.h>
-
-int cfl_init();
-char *cfl_version();
+int cfl_atomic_initialize();
+int cfl_atomic_compare_exchange(uint64_t *storage, uint64_t old_value,
+                                uint64_t new_value);
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value);
+uint64_t cfl_atomic_load(uint64_t *storage);
 
 #endif

--- a/include/cfl/cfl_container.h
+++ b/include/cfl/cfl_container.h
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CFL
+ *  ===
+ *  Copyright (C) 2026 The CFL Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CFL_CONTAINER_H
+#define CFL_CONTAINER_H
+
+#include <cfl/cfl_array.h>
+#include <cfl/cfl_kvlist.h>
+#include <cfl/cfl_variant.h>
+
+int cfl_container_array_contains_array(struct cfl_array *array,
+                                       struct cfl_array *target);
+int cfl_container_array_contains_kvlist(struct cfl_array *array,
+                                        struct cfl_kvlist *target);
+int cfl_container_array_contains_variant(struct cfl_array *array,
+                                         struct cfl_variant *target);
+
+int cfl_container_kvlist_contains_array(struct cfl_kvlist *kvlist,
+                                        struct cfl_array *target);
+int cfl_container_kvlist_contains_kvlist(struct cfl_kvlist *kvlist,
+                                         struct cfl_kvlist *target);
+int cfl_container_kvlist_contains_variant(struct cfl_kvlist *kvlist,
+                                          struct cfl_variant *target);
+
+int cfl_container_variant_contains_array(struct cfl_variant *variant,
+                                         struct cfl_array *target);
+int cfl_container_variant_contains_kvlist(struct cfl_variant *variant,
+                                          struct cfl_kvlist *target);
+int cfl_container_variant_contains_variant(struct cfl_variant *variant,
+                                           struct cfl_variant *target);
+
+#endif

--- a/include/cfl/cfl_kv.h
+++ b/include/cfl/cfl_kv.h
@@ -20,6 +20,8 @@
 #ifndef CFL_KV_H
 #define CFL_KV_H
 
+#include <stddef.h>
+
 #include <cfl/cfl_info.h>
 #include <cfl/cfl_sds.h>
 #include <cfl/cfl_list.h>

--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -41,6 +41,11 @@ struct cfl_kvlist {
 struct cfl_kvlist *cfl_kvlist_create();
 void cfl_kvlist_destroy(struct cfl_kvlist *list);
 
+/*
+ * Insert APIs take ownership of array, kvlist, and variant values on success.
+ * A value must have a single owning parent; inserting the same pointer into
+ * multiple containers is unsupported and can result in double-free.
+ */
 int cfl_kvlist_insert_string(struct cfl_kvlist *list,
                              char *key, char *value);
 

--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -21,6 +21,9 @@
 #define CFL_KVLIST_H
 
 #include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <cfl/cfl_sds.h>
 #include <cfl/cfl_list.h>
 #include <cfl/cfl_variant.h>

--- a/include/cfl/cfl_list.h
+++ b/include/cfl/cfl_list.h
@@ -31,6 +31,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifndef CFL_FALSE
+#define CFL_FALSE 0
+#endif
+
+#ifndef CFL_TRUE
+#define CFL_TRUE !CFL_FALSE
+#endif
+
 #ifdef _WIN32
 /* Windows */
 #define cfl_container_of(address, type, field) ((type *)(                   \
@@ -53,6 +61,10 @@ struct cfl_list {
 
 static inline int cfl_list_is_empty(struct cfl_list *head)
 {
+    if (head == NULL) {
+        return 1;
+    }
+
     if (head->next == head) {
         return 1;
     }
@@ -62,6 +74,10 @@ static inline int cfl_list_is_empty(struct cfl_list *head)
 
 static inline void cfl_list_init(struct cfl_list *list)
 {
+    if (list == NULL) {
+        return;
+    }
+
     list->next = list;
     list->prev = list;
 }
@@ -69,12 +85,20 @@ static inline void cfl_list_init(struct cfl_list *list)
 static inline void __cfl_list_del(struct cfl_list *prev,
                                   struct cfl_list *next)
 {
+    if (prev == NULL || next == NULL) {
+        return;
+    }
+
     prev->next = next;
     next->prev = prev;
 }
 
 static inline void cfl_list_del(struct cfl_list *entry)
 {
+    if (entry == NULL) {
+        return;
+    }
+
     __cfl_list_del(entry->prev, entry->next);
 
     entry->prev = NULL;
@@ -85,6 +109,10 @@ static inline void __cfl_list_add(struct cfl_list *_new,
                                   struct cfl_list *prev,
                                   struct cfl_list *next)
 {
+    if (_new == NULL || prev == NULL || next == NULL) {
+        return;
+    }
+
     next->prev = _new;
     _new->next = next;
     _new->prev = prev;
@@ -94,6 +122,10 @@ static inline void __cfl_list_add(struct cfl_list *_new,
 static inline void cfl_list_add(struct cfl_list *_new,
                                 struct cfl_list *head)
 {
+    if (_new == NULL || head == NULL) {
+        return;
+    }
+
     __cfl_list_add(_new, head->prev, head);
 }
 
@@ -134,6 +166,10 @@ static inline void cfl_list_add_before(struct cfl_list *_new,
 static inline void cfl_list_append(struct cfl_list *_new,
                                    struct cfl_list *head)
 {
+    if (_new == NULL || head == NULL) {
+        return;
+    }
+
     if (cfl_list_is_empty(head)) {
         __cfl_list_add(_new, head->prev, head);
     }
@@ -147,6 +183,10 @@ static inline void cfl_list_append(struct cfl_list *_new,
 static inline void cfl_list_prepend(struct cfl_list *_new,
                                     struct cfl_list *head)
 {
+    if (_new == NULL || head == NULL) {
+        return;
+    }
+
     if (cfl_list_is_empty(head)) {
         __cfl_list_add(_new, head->prev, head);
     }
@@ -162,6 +202,10 @@ static inline int cfl_list_size(struct cfl_list *head)
     int ret = 0;
     struct cfl_list *it;
 
+    if (head == NULL) {
+        return 0;
+    }
+
     for (it = head->next; it != head; it = it->next, ret++);
 
     return ret;
@@ -175,6 +219,10 @@ static inline void cfl_list_entry_init(struct cfl_list *entry)
 
 static inline int cfl_list_entry_is_orphan(struct cfl_list *entry)
 {
+    if (entry == NULL) {
+        return CFL_TRUE;
+    }
+
     if (entry->next != NULL &&
         entry->prev != NULL) {
         return CFL_FALSE;
@@ -186,6 +234,10 @@ static inline int cfl_list_entry_is_orphan(struct cfl_list *entry)
 static inline void cfl_list_cat(struct cfl_list *list, struct cfl_list *head)
 {
     struct cfl_list *last;
+
+    if (list == NULL || head == NULL) {
+        return;
+    }
 
     last = head->prev;
     last->next = list->next;

--- a/include/cfl/cfl_object.h
+++ b/include/cfl/cfl_object.h
@@ -20,6 +20,11 @@
 #ifndef CFL_OBJECT_H
 #define CFL_OBJECT_H
 
+#include <stdio.h>
+
+#include <cfl/cfl_list.h>
+#include <cfl/cfl_variant.h>
+
 enum {
     CFL_OBJECT_NONE = 0,
     CFL_OBJECT_KVLIST = 1,

--- a/include/cfl/cfl_sds.h
+++ b/include/cfl/cfl_sds.h
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <stdint.h>
 
 #define CFL_SDS_HEADER_SIZE (sizeof(uint64_t) + sizeof(uint64_t))
 
@@ -45,7 +46,19 @@ struct cfl_sds {
 
 static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
 {
-    CFL_SDS_HEADER(s)->len = len;
+    struct cfl_sds *head;
+
+    if (s == NULL) {
+        return;
+    }
+
+    head = CFL_SDS_HEADER(s);
+    if (len > head->alloc) {
+        return;
+    }
+
+    head->len = len;
+    s[len] = '\0';
 }
 
 size_t cfl_sds_avail(cfl_sds_t s);

--- a/include/cfl/cfl_time.h
+++ b/include/cfl/cfl_time.h
@@ -20,7 +20,7 @@
 #ifndef CFL_TIME_H
 #define CFL_TIME_H
 
-#include <cfl/cfl.h>
+#include <stdint.h>
 
 uint64_t cfl_time_now();
 

--- a/include/cfl/cfl_utils.h
+++ b/include/cfl/cfl_utils.h
@@ -2,7 +2,9 @@
 #define CFL_UTILS_H
 
 #include <sys/types.h> /* off_t */
+
 #include <cfl/cfl_sds.h>
+#include <cfl/cfl_list.h>
 #include <cfl/cfl_compat.h>
 
 struct cfl_split_entry {

--- a/include/cfl/cfl_variant.h
+++ b/include/cfl/cfl_variant.h
@@ -23,6 +23,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cfl/cfl_sds.h>
 
 #define CFL_VARIANT_BOOL       1
 #define CFL_VARIANT_INT        2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(src
   cfl_object.c
   cfl_array.c
   cfl_variant.c
+  cfl_container.c
   cfl_checksum.c
   cfl_utils.c
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,9 +12,34 @@ set(src
   cfl_utils.c
   )
 
+set(CFL_ATOMIC_NEEDS_THREADS Off)
+
+if(MSVC)
+  set(PLATFORM_SPECIFIC_ATOMIC_MODULE cfl_atomic_msvc.c)
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  set(PLATFORM_SPECIFIC_ATOMIC_MODULE cfl_atomic_clang.c)
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+  set(PLATFORM_SPECIFIC_ATOMIC_MODULE cfl_atomic_clang.c)
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(PLATFORM_SPECIFIC_ATOMIC_MODULE cfl_atomic_gcc.c)
+else()
+  set(PLATFORM_SPECIFIC_ATOMIC_MODULE cfl_atomic_generic.c)
+  set(CFL_ATOMIC_NEEDS_THREADS On)
+endif()
+
+set(src
+  ${src}
+  ${PLATFORM_SPECIFIC_ATOMIC_MODULE}
+  )
+
 # Static Library
 add_library(cfl-static STATIC ${src})
-target_link_libraries(cfl-static xxhash)
+target_link_libraries(cfl-static PRIVATE xxhash)
+
+if(CFL_ATOMIC_NEEDS_THREADS)
+  find_package(Threads REQUIRED)
+  target_link_libraries(cfl-static PUBLIC Threads::Threads)
+endif()
 
 # Install Library
 if(MSVC)

--- a/src/cfl.c
+++ b/src/cfl.c
@@ -21,11 +21,10 @@
 
 int cfl_init()
 {
-    return 0;
+    return cfl_atomic_initialize();
 }
 
 char *cfl_version()
 {
     return CFL_VERSION_STR;
 }
-

--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -156,18 +156,21 @@ int cfl_array_append(struct cfl_array *array,
         return -1;
     }
 
-    if (cfl_container_variant_contains_array(value, array)) {
-        return -1;
-    }
+    /* Only container-valued variants can participate in container cycles. */
+    if (value->type == CFL_VARIANT_ARRAY || value->type == CFL_VARIANT_KVLIST) {
+        if (cfl_container_variant_contains_array(value, array)) {
+            return -1;
+        }
 
-    if (value->type == CFL_VARIANT_ARRAY &&
-        cfl_container_array_contains_array(array, value->data.as_array)) {
-        return -1;
-    }
+        if (value->type == CFL_VARIANT_ARRAY &&
+            cfl_container_array_contains_array(array, value->data.as_array)) {
+            return -1;
+        }
 
-    if (value->type == CFL_VARIANT_KVLIST &&
-        cfl_container_array_contains_kvlist(array, value->data.as_kvlist)) {
-        return -1;
+        if (value->type == CFL_VARIANT_KVLIST &&
+            cfl_container_array_contains_kvlist(array, value->data.as_kvlist)) {
+            return -1;
+        }
     }
 
     if (array->entry_count >= array->slot_count) {

--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -23,6 +23,8 @@
 
 #include <stdint.h>
 
+#include <cfl/cfl_container.h>
+
 struct cfl_array *cfl_array_create(size_t slot_count)
 {
     struct cfl_array *array;
@@ -147,6 +149,24 @@ int cfl_array_append(struct cfl_array *array,
     size_t base_slot_count;
 
     if (array == NULL || value == NULL) {
+        return -1;
+    }
+
+    if (cfl_container_array_contains_variant(array, value)) {
+        return -1;
+    }
+
+    if (cfl_container_variant_contains_array(value, array)) {
+        return -1;
+    }
+
+    if (value->type == CFL_VARIANT_ARRAY &&
+        cfl_container_array_contains_array(array, value->data.as_array)) {
+        return -1;
+    }
+
+    if (value->type == CFL_VARIANT_KVLIST &&
+        cfl_container_array_contains_kvlist(array, value->data.as_kvlist)) {
         return -1;
     }
 
@@ -397,6 +417,11 @@ int cfl_array_append_array(struct cfl_array *array, struct cfl_array *value)
         return -1;
     }
 
+    if (cfl_container_array_contains_array(array, value) ||
+        cfl_container_array_contains_array(value, array)) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_array(value);
 
     if (value_instance == NULL) {
@@ -445,6 +470,11 @@ int cfl_array_append_kvlist(struct cfl_array *array, struct cfl_kvlist *value)
         return -1;
     }
 
+    if (cfl_container_array_contains_kvlist(array, value) ||
+        cfl_container_kvlist_contains_array(value, array)) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_kvlist(value);
     if (value_instance == NULL) {
         return -1;
@@ -473,17 +503,36 @@ int cfl_array_print(FILE *fp, struct cfl_array *array)
 
     size = array->entry_count;
     if (size == 0) {
-        fputs("[]", fp);
+        if (fputs("[]", fp) == EOF) {
+            return -1;
+        }
+
         return 0;
     }
 
-    fputs("[", fp);
+    if (fputc('[', fp) == EOF) {
+        return -1;
+    }
+
     for (i=0; i<size-1; i++) {
         ret = cfl_variant_print(fp, array->entries[i]);
-        fputs(",", fp);
+        if (ret < 0) {
+            return -1;
+        }
+
+        if (fputc(',', fp) == EOF) {
+            return -1;
+        }
     }
+
     ret = cfl_variant_print(fp, array->entries[size-1]);
-    fputs("]", fp);
+    if (ret < 0) {
+        return -1;
+    }
+
+    if (fputc(']', fp) == EOF) {
+        return -1;
+    }
 
     return ret;
 }

--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -21,9 +21,12 @@
 #include <cfl/cfl_array.h>
 #include <cfl/cfl_variant.h>
 
+#include <stdint.h>
+
 struct cfl_array *cfl_array_create(size_t slot_count)
 {
     struct cfl_array *array;
+    size_t alloc_count;
 
     array = malloc(sizeof(struct cfl_array));
     if (array == NULL) {
@@ -35,7 +38,16 @@ struct cfl_array *cfl_array_create(size_t slot_count)
     array->resizable = CFL_FALSE;
 
     /* allocate fixed number of entries */
-    array->entries = calloc(slot_count, sizeof(void *));
+    alloc_count = slot_count;
+    if (alloc_count == 0) {
+        alloc_count = 1;
+    }
+    if (alloc_count > SIZE_MAX / sizeof(void *)) {
+        free(array);
+        return NULL;
+    }
+
+    array->entries = calloc(alloc_count, sizeof(void *));
     if (array->entries == NULL) {
         cfl_errno();
         free(array);
@@ -70,6 +82,10 @@ void cfl_array_destroy(struct cfl_array *array)
 
 int cfl_array_resizable(struct cfl_array *array, int v)
 {
+    if (array == NULL) {
+        return -1;
+    }
+
     if (v != CFL_TRUE && v != CFL_FALSE) {
         return -1;
     }
@@ -81,6 +97,10 @@ int cfl_array_resizable(struct cfl_array *array, int v)
 int cfl_array_remove_by_index(struct cfl_array *array,
                               size_t position)
 {
+    if (array == NULL) {
+        return -1;
+    }
+
     if (position >= array->entry_count) {
         return -1;
     }
@@ -105,6 +125,10 @@ int cfl_array_remove_by_reference(struct cfl_array *array,
 {
     size_t index;
 
+    if (array == NULL || value == NULL) {
+        return -1;
+    }
+
     for (index = 0 ; index < array->entry_count ; index++) {
         if (array->entries[index] == value) {
             return cfl_array_remove_by_index(array, index);
@@ -120,6 +144,11 @@ int cfl_array_append(struct cfl_array *array,
     void *tmp;
     size_t new_slot_count;
     size_t new_size;
+    size_t base_slot_count;
+
+    if (array == NULL || value == NULL) {
+        return -1;
+    }
 
     if (array->entry_count >= array->slot_count) {
         /*
@@ -129,17 +158,21 @@ int cfl_array_append(struct cfl_array *array,
          * it controls the input data.
          */
         if (array->resizable) {
-
-            /*
-             * if the array size is zero (created as an array of 0 slots),
-             * change the size to 1 so the resize can work properly
-             */
-            if (array->slot_count == 0) {
-                array->slot_count = 1;
+            base_slot_count = array->slot_count;
+            if (base_slot_count == 0) {
+                base_slot_count = 1;
             }
 
             /* set new number of slots and total size */
-            new_slot_count = (array->slot_count * 2);
+            if (base_slot_count > SIZE_MAX / 2) {
+                return -1;
+            }
+
+            new_slot_count = (base_slot_count * 2);
+            if (new_slot_count > SIZE_MAX / sizeof(void *)) {
+                return -1;
+            }
+
             new_size = (new_slot_count * sizeof(void *));
 
             tmp = realloc(array->entries, new_size);
@@ -360,6 +393,10 @@ int cfl_array_append_array(struct cfl_array *array, struct cfl_array *value)
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (array == NULL || value == NULL) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_array(value);
 
     if (value_instance == NULL) {
@@ -381,6 +418,10 @@ int cfl_array_append_new_array(struct cfl_array *array, size_t size)
     int               result;
     struct cfl_array *value;
 
+    if (array == NULL) {
+        return -1;
+    }
+
     value = cfl_array_create(size);
 
     if (value == NULL) {
@@ -388,8 +429,7 @@ int cfl_array_append_new_array(struct cfl_array *array, size_t size)
     }
 
     result = cfl_array_append_array(array, value);
-
-    if (result) {
+    if (result == -1) {
         cfl_array_destroy(value);
     }
 
@@ -400,6 +440,10 @@ int cfl_array_append_kvlist(struct cfl_array *array, struct cfl_kvlist *value)
 {
     struct cfl_variant *value_instance;
     int                 result;
+
+    if (array == NULL || value == NULL) {
+        return -1;
+    }
 
     value_instance = cfl_variant_create_from_kvlist(value);
     if (value_instance == NULL) {

--- a/src/cfl_atomic_clang.c
+++ b/src/cfl_atomic_clang.c
@@ -17,30 +17,26 @@
  *  limitations under the License.
  */
 
-#ifndef CFL_H
-#define CFL_H
-
-#define CFL_FALSE   0
-#define CFL_TRUE    !CFL_FALSE
-
-/* headers that are needed in general */
-#include <cfl/cfl_info.h>
-#include <cfl/cfl_version.h>
-#include <cfl/cfl_compat.h>
 #include <cfl/cfl_atomic.h>
-#include <cfl/cfl_log.h>
-#include <cfl/cfl_sds.h>
-#include <cfl/cfl_list.h>
-#include <cfl/cfl_hash.h>
-#include <cfl/cfl_array.h>
-#include <cfl/cfl_kv.h>
-#include <cfl/cfl_kvlist.h>
-#include <cfl/cfl_time.h>
-#include <cfl/cfl_variant.h>
-#include <cfl/cfl_object.h>
-#include <cfl/cfl_utils.h>
 
-int cfl_init();
-char *cfl_version();
+int cfl_atomic_initialize()
+{
+    return 0;
+}
 
-#endif
+int cfl_atomic_compare_exchange(uint64_t *storage,
+                                uint64_t old_value, uint64_t new_value)
+{
+    return __atomic_compare_exchange(storage, &old_value, &new_value, 0,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value)
+{
+    __atomic_store_n(storage, new_value, __ATOMIC_SEQ_CST);
+}
+
+uint64_t cfl_atomic_load(uint64_t *storage)
+{
+    return __atomic_load_n(storage, __ATOMIC_SEQ_CST);
+}

--- a/src/cfl_atomic_gcc.c
+++ b/src/cfl_atomic_gcc.c
@@ -17,30 +17,26 @@
  *  limitations under the License.
  */
 
-#ifndef CFL_H
-#define CFL_H
-
-#define CFL_FALSE   0
-#define CFL_TRUE    !CFL_FALSE
-
-/* headers that are needed in general */
-#include <cfl/cfl_info.h>
-#include <cfl/cfl_version.h>
-#include <cfl/cfl_compat.h>
 #include <cfl/cfl_atomic.h>
-#include <cfl/cfl_log.h>
-#include <cfl/cfl_sds.h>
-#include <cfl/cfl_list.h>
-#include <cfl/cfl_hash.h>
-#include <cfl/cfl_array.h>
-#include <cfl/cfl_kv.h>
-#include <cfl/cfl_kvlist.h>
-#include <cfl/cfl_time.h>
-#include <cfl/cfl_variant.h>
-#include <cfl/cfl_object.h>
-#include <cfl/cfl_utils.h>
 
-int cfl_init();
-char *cfl_version();
+int cfl_atomic_initialize()
+{
+    return 0;
+}
 
-#endif
+int cfl_atomic_compare_exchange(uint64_t *storage,
+                                uint64_t old_value, uint64_t new_value)
+{
+    return __atomic_compare_exchange(storage, &old_value, &new_value, 0,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value)
+{
+    __atomic_store_n(storage, new_value, __ATOMIC_SEQ_CST);
+}
+
+uint64_t cfl_atomic_load(uint64_t *storage)
+{
+    return __atomic_load_n(storage, __ATOMIC_SEQ_CST);
+}

--- a/src/cfl_atomic_generic.c
+++ b/src/cfl_atomic_generic.c
@@ -1,0 +1,121 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CFL
+ *  ===
+ *  Copyright (C) 2022 The CFL Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <pthread.h>
+
+#include <cfl/cfl_atomic.h>
+
+static pthread_mutex_t cfl_atomic_operation_lock;
+static pthread_once_t  cfl_atomic_operation_system_once = PTHREAD_ONCE_INIT;
+static int             cfl_atomic_operation_system_initialized = 0;
+static int             cfl_atomic_operation_system_status = 0;
+
+static void cfl_atomic_bootstrap()
+{
+    cfl_atomic_operation_system_status =
+        pthread_mutex_init(&cfl_atomic_operation_lock, NULL);
+
+    if (cfl_atomic_operation_system_status == 0) {
+        cfl_atomic_operation_system_initialized = 1;
+    }
+}
+
+int cfl_atomic_initialize()
+{
+    pthread_once(&cfl_atomic_operation_system_once, cfl_atomic_bootstrap);
+
+    if (cfl_atomic_operation_system_status != 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+int cfl_atomic_compare_exchange(uint64_t *storage,
+                                uint64_t old_value, uint64_t new_value)
+{
+    int result;
+
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0) {
+        return 0;
+    }
+
+    result = pthread_mutex_lock(&cfl_atomic_operation_lock);
+
+    if (result != 0) {
+        return 0;
+    }
+
+    if (*storage == old_value) {
+        *storage = new_value;
+
+        result = 1;
+    }
+    else {
+        result = 0;
+    }
+
+    pthread_mutex_unlock(&cfl_atomic_operation_lock);
+
+    return result;
+}
+
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value)
+{
+    int result;
+
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0) {
+        return;
+    }
+
+    result = pthread_mutex_lock(&cfl_atomic_operation_lock);
+
+    if (result != 0) {
+        return;
+    }
+
+    *storage = new_value;
+
+    pthread_mutex_unlock(&cfl_atomic_operation_lock);
+}
+
+uint64_t cfl_atomic_load(uint64_t *storage)
+{
+    int      result;
+    uint64_t retval;
+
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0) {
+        return 0;
+    }
+
+    result = pthread_mutex_lock(&cfl_atomic_operation_lock);
+
+    if (result != 0) {
+        return 0;
+    }
+
+    retval = *storage;
+
+    pthread_mutex_unlock(&cfl_atomic_operation_lock);
+
+    return retval;
+}

--- a/src/cfl_atomic_msvc.c
+++ b/src/cfl_atomic_msvc.c
@@ -1,0 +1,160 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CFL
+ *  ===
+ *  Copyright (C) 2022 The CFL Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cfl/cfl_atomic.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#else
+#include <windows.h>
+#endif
+
+#ifdef _WIN64
+#include <intrin.h>
+#endif
+
+#ifndef _WIN64
+static CRITICAL_SECTION cfl_atomic_operation_lock;
+static INIT_ONCE        cfl_atomic_operation_system_once = INIT_ONCE_STATIC_INIT;
+static int              cfl_atomic_operation_system_initialized = 0;
+static int              cfl_atomic_operation_system_status = 0;
+
+static BOOL CALLBACK cfl_atomic_bootstrap(PINIT_ONCE once, PVOID parameter,
+                                          PVOID *context)
+{
+    (void) once;
+    (void) parameter;
+    (void) context;
+
+    InitializeCriticalSection(&cfl_atomic_operation_lock);
+    cfl_atomic_operation_system_initialized = 1;
+
+    return TRUE;
+}
+
+int cfl_atomic_initialize()
+{
+    if (!InitOnceExecuteOnce(&cfl_atomic_operation_system_once,
+                             cfl_atomic_bootstrap, NULL, NULL)) {
+        cfl_atomic_operation_system_status = 1;
+        return 1;
+    }
+
+    cfl_atomic_operation_system_status = 0;
+
+    return 0;
+}
+
+int cfl_atomic_compare_exchange(uint64_t *storage,
+                                uint64_t old_value, uint64_t new_value)
+{
+    int result;
+
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0 ||
+        cfl_atomic_operation_system_status != 0) {
+        return 0;
+    }
+
+    EnterCriticalSection(&cfl_atomic_operation_lock);
+
+    if (*storage == old_value) {
+        *storage = new_value;
+
+        result = 1;
+    }
+    else {
+        result = 0;
+    }
+
+    LeaveCriticalSection(&cfl_atomic_operation_lock);
+
+    return result;
+}
+
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value)
+{
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0 ||
+        cfl_atomic_operation_system_status != 0) {
+        return;
+    }
+
+    EnterCriticalSection(&cfl_atomic_operation_lock);
+
+    *storage = new_value;
+
+    LeaveCriticalSection(&cfl_atomic_operation_lock);
+}
+
+uint64_t cfl_atomic_load(uint64_t *storage)
+{
+    uint64_t result;
+
+    if (cfl_atomic_initialize() != 0 ||
+        cfl_atomic_operation_system_initialized == 0 ||
+        cfl_atomic_operation_system_status != 0) {
+        return 0;
+    }
+
+    EnterCriticalSection(&cfl_atomic_operation_lock);
+
+    result = *storage;
+
+    LeaveCriticalSection(&cfl_atomic_operation_lock);
+
+    return result;
+}
+
+#else /* _WIN64 */
+
+int cfl_atomic_initialize()
+{
+    return 0;
+}
+
+int cfl_atomic_compare_exchange(uint64_t *storage,
+                                uint64_t old_value, uint64_t new_value)
+{
+    __int64 result;
+
+    result = _InterlockedCompareExchange64((volatile __int64 *) storage,
+                                           (__int64) new_value,
+                                           (__int64) old_value);
+
+    if ((uint64_t) result != old_value) {
+        return 0;
+    }
+
+    return 1;
+}
+
+void cfl_atomic_store(uint64_t *storage, uint64_t new_value)
+{
+    _InterlockedExchange64((volatile __int64 *) storage, (__int64) new_value);
+}
+
+uint64_t cfl_atomic_load(uint64_t *storage)
+{
+    return (uint64_t) _InterlockedOr64((volatile __int64 *) storage, 0);
+}
+
+#endif

--- a/src/cfl_checksum.c
+++ b/src/cfl_checksum.c
@@ -93,6 +93,10 @@ uint32_t cfl_checksum_crc32c(unsigned char *buffer, size_t length)
     uint32_t checksum;
     size_t   index;
 
+    if (buffer == NULL && length > 0) {
+        return 0;
+    }
+
     checksum = 0xFFFFFFFF;
 
     /* Keeping in mind that compilers are smart enough to optimize these

--- a/src/cfl_container.c
+++ b/src/cfl_container.c
@@ -1,0 +1,325 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CFL
+ *  ===
+ *  Copyright (C) 2026 The CFL Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cfl/cfl.h>
+
+#include <cfl/cfl_container.h>
+
+#define CFL_CONTAINER_MAX_DEPTH 512
+
+static int variant_contains_array(struct cfl_variant *variant,
+                                  struct cfl_array *target,
+                                  size_t depth);
+static int variant_contains_kvlist(struct cfl_variant *variant,
+                                   struct cfl_kvlist *target,
+                                   size_t depth);
+static int variant_contains_variant(struct cfl_variant *variant,
+                                    struct cfl_variant *target,
+                                    size_t depth);
+
+static int depth_exceeded(size_t depth)
+{
+    if (depth > CFL_CONTAINER_MAX_DEPTH) {
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+static int array_contains_array(struct cfl_array *array,
+                                struct cfl_array *target,
+                                size_t depth)
+{
+    size_t i;
+
+    if (array == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    if (array == target) {
+        return CFL_TRUE;
+    }
+
+    for (i = 0; i < array->entry_count; i++) {
+        if (variant_contains_array(array->entries[i], target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int array_contains_kvlist(struct cfl_array *array,
+                                 struct cfl_kvlist *target,
+                                 size_t depth)
+{
+    size_t i;
+
+    if (array == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    for (i = 0; i < array->entry_count; i++) {
+        if (variant_contains_kvlist(array->entries[i], target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int array_contains_variant(struct cfl_array *array,
+                                  struct cfl_variant *target,
+                                  size_t depth)
+{
+    size_t i;
+
+    if (array == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    for (i = 0; i < array->entry_count; i++) {
+        if (variant_contains_variant(array->entries[i], target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int kvlist_contains_array(struct cfl_kvlist *kvlist,
+                                 struct cfl_array *target,
+                                 size_t depth)
+{
+    struct cfl_list *head;
+    struct cfl_kvpair *pair;
+
+    if (kvlist == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    cfl_list_foreach(head, &kvlist->list) {
+        pair = cfl_list_entry(head, struct cfl_kvpair, _head);
+
+        if (pair != NULL && variant_contains_array(pair->val, target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int kvlist_contains_kvlist(struct cfl_kvlist *kvlist,
+                                  struct cfl_kvlist *target,
+                                  size_t depth)
+{
+    struct cfl_list *head;
+    struct cfl_kvpair *pair;
+
+    if (kvlist == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    if (kvlist == target) {
+        return CFL_TRUE;
+    }
+
+    cfl_list_foreach(head, &kvlist->list) {
+        pair = cfl_list_entry(head, struct cfl_kvpair, _head);
+
+        if (pair != NULL && variant_contains_kvlist(pair->val, target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int kvlist_contains_variant(struct cfl_kvlist *kvlist,
+                                   struct cfl_variant *target,
+                                   size_t depth)
+{
+    struct cfl_list *head;
+    struct cfl_kvpair *pair;
+
+    if (kvlist == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    cfl_list_foreach(head, &kvlist->list) {
+        pair = cfl_list_entry(head, struct cfl_kvpair, _head);
+
+        if (pair != NULL && variant_contains_variant(pair->val, target, depth + 1)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int variant_contains_array(struct cfl_variant *variant,
+                                  struct cfl_array *target,
+                                  size_t depth)
+{
+    if (variant == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    if (variant->type == CFL_VARIANT_ARRAY) {
+        return array_contains_array(variant->data.as_array, target, depth + 1);
+    }
+
+    if (variant->type == CFL_VARIANT_KVLIST) {
+        return kvlist_contains_array(variant->data.as_kvlist, target, depth + 1);
+    }
+
+    return CFL_FALSE;
+}
+
+static int variant_contains_kvlist(struct cfl_variant *variant,
+                                   struct cfl_kvlist *target,
+                                   size_t depth)
+{
+    if (variant == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    if (variant->type == CFL_VARIANT_ARRAY) {
+        return array_contains_kvlist(variant->data.as_array, target, depth + 1);
+    }
+
+    if (variant->type == CFL_VARIANT_KVLIST) {
+        return kvlist_contains_kvlist(variant->data.as_kvlist, target, depth + 1);
+    }
+
+    return CFL_FALSE;
+}
+
+static int variant_contains_variant(struct cfl_variant *variant,
+                                    struct cfl_variant *target,
+                                    size_t depth)
+{
+    if (variant == NULL || target == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (depth_exceeded(depth)) {
+        return CFL_TRUE;
+    }
+
+    if (variant == target) {
+        return CFL_TRUE;
+    }
+
+    if (variant->type == CFL_VARIANT_ARRAY) {
+        return array_contains_variant(variant->data.as_array, target, depth + 1);
+    }
+
+    if (variant->type == CFL_VARIANT_KVLIST) {
+        return kvlist_contains_variant(variant->data.as_kvlist, target, depth + 1);
+    }
+
+    return CFL_FALSE;
+}
+
+int cfl_container_array_contains_array(struct cfl_array *array,
+                                       struct cfl_array *target)
+{
+    return array_contains_array(array, target, 0);
+}
+
+int cfl_container_array_contains_kvlist(struct cfl_array *array,
+                                        struct cfl_kvlist *target)
+{
+    return array_contains_kvlist(array, target, 0);
+}
+
+int cfl_container_array_contains_variant(struct cfl_array *array,
+                                         struct cfl_variant *target)
+{
+    return array_contains_variant(array, target, 0);
+}
+
+int cfl_container_kvlist_contains_array(struct cfl_kvlist *kvlist,
+                                        struct cfl_array *target)
+{
+    return kvlist_contains_array(kvlist, target, 0);
+}
+
+int cfl_container_kvlist_contains_kvlist(struct cfl_kvlist *kvlist,
+                                         struct cfl_kvlist *target)
+{
+    return kvlist_contains_kvlist(kvlist, target, 0);
+}
+
+int cfl_container_kvlist_contains_variant(struct cfl_kvlist *kvlist,
+                                          struct cfl_variant *target)
+{
+    return kvlist_contains_variant(kvlist, target, 0);
+}
+
+int cfl_container_variant_contains_array(struct cfl_variant *variant,
+                                         struct cfl_array *target)
+{
+    return variant_contains_array(variant, target, 0);
+}
+
+int cfl_container_variant_contains_kvlist(struct cfl_variant *variant,
+                                          struct cfl_kvlist *target)
+{
+    return variant_contains_kvlist(variant, target, 0);
+}
+
+int cfl_container_variant_contains_variant(struct cfl_variant *variant,
+                                           struct cfl_variant *target)
+{
+    return variant_contains_variant(variant, target, 0);
+}

--- a/src/cfl_kv.c
+++ b/src/cfl_kv.c
@@ -21,9 +21,14 @@
 #include <cfl/cfl_kv.h>
 #include <cfl/cfl_log.h>
 
+#include <limits.h>
 
 void cfl_kv_init(struct cfl_list *list)
 {
+    if (list == NULL) {
+        return;
+    }
+
     cfl_list_init(list);
 }
 
@@ -33,6 +38,14 @@ struct cfl_kv *cfl_kv_item_create_len(struct cfl_list *list,
 {
     struct cfl_kv *kv;
 
+    if (list == NULL || k_buf == NULL || k_len > INT_MAX || v_len > INT_MAX) {
+        return NULL;
+    }
+
+    if (v_len > 0 && v_buf == NULL) {
+        return NULL;
+    }
+
     kv = calloc(1, sizeof(struct cfl_kv));
 
     if (kv == NULL) {
@@ -41,7 +54,7 @@ struct cfl_kv *cfl_kv_item_create_len(struct cfl_list *list,
         return NULL;
     }
 
-    kv->key = cfl_sds_create_len(k_buf, k_len);
+    kv->key = cfl_sds_create_len(k_buf, (int) k_len);
 
     if (kv->key == NULL) {
         free(kv);
@@ -50,7 +63,7 @@ struct cfl_kv *cfl_kv_item_create_len(struct cfl_list *list,
     }
 
     if (v_len > 0) {
-        kv->val = cfl_sds_create_len(v_buf, v_len);
+        kv->val = cfl_sds_create_len(v_buf, (int) v_len);
 
         if (kv->val == NULL) {
             cfl_sds_destroy(kv->key);
@@ -68,10 +81,10 @@ struct cfl_kv *cfl_kv_item_create_len(struct cfl_list *list,
 struct cfl_kv *cfl_kv_item_create(struct cfl_list *list,
                                   char *k_buf, char *v_buf)
 {
-    int k_len;
-    int v_len;
+    size_t k_len;
+    size_t v_len;
 
-    if (k_buf == NULL) {
+    if (list == NULL || k_buf == NULL) {
         return NULL;
     }
 
@@ -84,11 +97,19 @@ struct cfl_kv *cfl_kv_item_create(struct cfl_list *list,
         v_len = 0;
     }
 
+    if (k_len > INT_MAX || v_len > INT_MAX) {
+        return NULL;
+    }
+
     return cfl_kv_item_create_len(list, k_buf, k_len, v_buf, v_len);
 }
 
 void cfl_kv_item_destroy(struct cfl_kv *kv)
 {
+    if (kv == NULL) {
+        return;
+    }
+
     if (kv->key != NULL) {
         cfl_sds_destroy(kv->key);
     }
@@ -108,6 +129,10 @@ void cfl_kv_release(struct cfl_list *list)
     struct cfl_list *tmp;
     struct cfl_kv   *kv;
 
+    if (list == NULL) {
+        return;
+    }
+
     cfl_list_foreach_safe(head, tmp, list) {
         kv = cfl_list_entry(head, struct cfl_kv, _head);
 
@@ -118,10 +143,10 @@ void cfl_kv_release(struct cfl_list *list)
 const char *cfl_kv_get_key_value(const char *key, struct cfl_list *list)
 {
     struct cfl_list *head;
-    int              len;
+    size_t           len;
     struct cfl_kv   *kv;
 
-    if (key == NULL) {
+    if (key == NULL || list == NULL) {
         return NULL;
     }
 

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -25,6 +25,8 @@
 
 #include <limits.h>
 
+#include <cfl/cfl_container.h>
+
 static int print_json_string(FILE *fp, const char *str, size_t len)
 {
     size_t i;
@@ -322,6 +324,11 @@ int cfl_kvlist_insert_array_s(struct cfl_kvlist *list,
         return -1;
     }
 
+    if (cfl_container_kvlist_contains_array(list, value) ||
+        cfl_container_array_contains_kvlist(value, list)) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_array(value);
 
     if (value_instance == NULL) {
@@ -374,6 +381,11 @@ int cfl_kvlist_insert_kvlist_s(struct cfl_kvlist *list,
         return -1;
     }
 
+    if (cfl_container_kvlist_contains_kvlist(list, value) ||
+        cfl_container_kvlist_contains_kvlist(value, list)) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_kvlist(value);
     if (value_instance == NULL) {
         return -1;
@@ -397,6 +409,24 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
     struct cfl_kvpair *pair;
 
     if (list == NULL || key == NULL || value == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
+    if (cfl_container_kvlist_contains_variant(list, value)) {
+        return -1;
+    }
+
+    if (cfl_container_variant_contains_kvlist(value, list)) {
+        return -1;
+    }
+
+    if (value->type == CFL_VARIANT_ARRAY &&
+        cfl_container_kvlist_contains_array(list, value->data.as_array)) {
+        return -1;
+    }
+
+    if (value->type == CFL_VARIANT_KVLIST &&
+        cfl_container_kvlist_contains_kvlist(list, value->data.as_kvlist)) {
         return -1;
     }
 
@@ -596,7 +626,10 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
     }
 
     printed = CFL_FALSE;
-    fputs("{", fp);
+    if (fputc('{', fp) == EOF) {
+        return -1;
+    }
+
     cfl_list_foreach(head, &list->list) {
         pair = cfl_list_entry(head, struct cfl_kvpair, _head);
         if (pair == NULL || pair->key == NULL || pair->val == NULL) {
@@ -604,7 +637,9 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
         }
 
         if (printed) {
-            fputs(",", fp);
+            if (fputc(',', fp) == EOF) {
+                return -1;
+            }
         }
 
         key_size = cfl_sds_len(pair->key);
@@ -613,7 +648,10 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
             return -1;
         }
 
-        fputs(":", fp);
+        if (fputc(':', fp) == EOF) {
+            return -1;
+        }
+
         ret = cfl_variant_print(fp, pair->val);
         if (ret < 0) {
             return -1;
@@ -621,7 +659,10 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
 
         printed = CFL_TRUE;
     }
-    fputs("}", fp);
+
+    if (fputc('}', fp) == EOF) {
+        return -1;
+    }
 
     return ret;
 }
@@ -630,16 +671,25 @@ int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name)
 {
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
+    size_t             name_len;
+    size_t             key_len;
 
     if (kvlist == NULL || name == NULL) {
         return CFL_FALSE;
     }
 
+    name_len = strlen(name);
+
     cfl_list_foreach(iterator, &kvlist->list) {
         pair = cfl_list_entry(iterator,
                               struct cfl_kvpair, _head);
 
-        if (strcasecmp(pair->key, name) == 0) {
+        key_len = cfl_sds_len(pair->key);
+        if (key_len != name_len) {
+            continue;
+        }
+
+        if (strncasecmp(pair->key, name, name_len) == 0) {
             return CFL_TRUE;
         }
     }
@@ -653,21 +703,33 @@ int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name)
     struct cfl_list   *iterator_backup;
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
+    size_t             name_len;
+    size_t             key_len;
+    int                removed;
 
     if (kvlist == NULL || name == NULL) {
         return CFL_FALSE;
     }
 
+    name_len = strlen(name);
+    removed = CFL_FALSE;
+
     cfl_list_foreach_safe(iterator, iterator_backup, &kvlist->list) {
         pair = cfl_list_entry(iterator,
                               struct cfl_kvpair, _head);
 
-        if (strcasecmp(pair->key, name) == 0) {
+        key_len = cfl_sds_len(pair->key);
+        if (key_len != name_len) {
+            continue;
+        }
+
+        if (strncasecmp(pair->key, name, name_len) == 0) {
             cfl_kvpair_destroy(pair);
+            removed = CFL_TRUE;
         }
     }
 
-    return CFL_TRUE;
+    return removed;
 }
 
 

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -23,6 +23,65 @@
 #include <cfl/cfl_variant.h>
 #include <cfl/cfl_compat.h>
 
+#include <limits.h>
+
+static int print_json_string(FILE *fp, const char *str, size_t len)
+{
+    size_t i;
+    unsigned char c;
+    int ret;
+
+    if (fputc('"', fp) == EOF) {
+        return -1;
+    }
+
+    for (i = 0; i < len; i++) {
+        c = (unsigned char) str[i];
+
+        switch (c) {
+        case '"':
+            ret = fputs("\\\"", fp);
+            break;
+        case '\\':
+            ret = fputs("\\\\", fp);
+            break;
+        case '\b':
+            ret = fputs("\\b", fp);
+            break;
+        case '\f':
+            ret = fputs("\\f", fp);
+            break;
+        case '\n':
+            ret = fputs("\\n", fp);
+            break;
+        case '\r':
+            ret = fputs("\\r", fp);
+            break;
+        case '\t':
+            ret = fputs("\\t", fp);
+            break;
+        default:
+            if (c < 0x20) {
+                ret = fprintf(fp, "\\u%04x", c);
+            }
+            else {
+                ret = fputc(c, fp);
+            }
+            break;
+        }
+
+        if (ret < 0) {
+            return -1;
+        }
+    }
+
+    if (fputc('"', fp) == EOF) {
+        return -1;
+    }
+
+    return 0;
+}
+
 struct cfl_kvlist *cfl_kvlist_create()
 {
     struct cfl_kvlist *list;
@@ -42,6 +101,10 @@ void cfl_kvlist_destroy(struct cfl_kvlist *list)
     struct cfl_list *tmp;
     struct cfl_list *head;
     struct cfl_kvpair *pair;
+
+    if (list == NULL) {
+        return;
+    }
 
     cfl_list_foreach_safe(head, tmp, &list->list) {
         pair = cfl_list_entry(head, struct cfl_kvpair, _head);
@@ -68,6 +131,10 @@ int cfl_kvlist_insert_string_s(struct cfl_kvlist *list,
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_string_s(value, value_size, referenced);
     if (value_instance == NULL) {
         return -1;
@@ -91,6 +158,10 @@ int cfl_kvlist_insert_bytes_s(struct cfl_kvlist *list,
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_bytes(value, length, referenced);
     if (value_instance == NULL) {
         return -1;
@@ -111,6 +182,10 @@ int cfl_kvlist_insert_reference_s(struct cfl_kvlist *list,
 {
     struct cfl_variant *value_instance;
     int                 result;
+
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
 
     value_instance = cfl_variant_create_from_reference(value);
 
@@ -135,6 +210,10 @@ int cfl_kvlist_insert_bool_s(struct cfl_kvlist *list,
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_bool(value);
 
     if (value_instance == NULL) {
@@ -157,6 +236,10 @@ int cfl_kvlist_insert_int64_s(struct cfl_kvlist *list,
 {
     struct cfl_variant *value_instance;
     int                 result;
+
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
 
     value_instance = cfl_variant_create_from_int64(value);
 
@@ -181,6 +264,10 @@ int cfl_kvlist_insert_uint64_s(struct cfl_kvlist *list,
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_uint64(value);
 
     if (value_instance == NULL) {
@@ -204,6 +291,10 @@ int cfl_kvlist_insert_double_s(struct cfl_kvlist *list,
     struct cfl_variant *value_instance;
     int                 result;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value_instance = cfl_variant_create_from_double(value);
 
     if (value_instance == NULL) {
@@ -226,6 +317,10 @@ int cfl_kvlist_insert_array_s(struct cfl_kvlist *list,
 {
     struct cfl_variant *value_instance;
     int                 result;
+
+    if (list == NULL || key == NULL || key_size > INT_MAX || value == NULL) {
+        return -1;
+    }
 
     value_instance = cfl_variant_create_from_array(value);
 
@@ -251,6 +346,10 @@ int cfl_kvlist_insert_new_array_s(struct cfl_kvlist *list,
     int               result;
     struct cfl_array *value;
 
+    if (list == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
     value = cfl_array_create(size);
 
     if (value == NULL) {
@@ -258,8 +357,7 @@ int cfl_kvlist_insert_new_array_s(struct cfl_kvlist *list,
     }
 
     result = cfl_kvlist_insert_array_s(list, key, key_size, value);
-
-    if (result) {
+    if (result == -1) {
         cfl_array_destroy(value);
     }
 
@@ -271,6 +369,10 @@ int cfl_kvlist_insert_kvlist_s(struct cfl_kvlist *list,
 {
     struct cfl_variant *value_instance;
     int                 result;
+
+    if (list == NULL || key == NULL || key_size > INT_MAX || value == NULL) {
+        return -1;
+    }
 
     value_instance = cfl_variant_create_from_kvlist(value);
     if (value_instance == NULL) {
@@ -294,7 +396,7 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
 {
     struct cfl_kvpair *pair;
 
-    if (list == NULL || key == NULL || value == NULL) {
+    if (list == NULL || key == NULL || value == NULL || key_size > INT_MAX) {
         return -1;
     }
 
@@ -304,7 +406,7 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    pair->key = cfl_sds_create_len(key, key_size);
+    pair->key = cfl_sds_create_len(key, (int) key_size);
     if (pair->key == NULL) {
         free(pair);
 
@@ -321,6 +423,10 @@ struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_
 {
     struct cfl_list *head;
     struct cfl_kvpair *pair;
+
+    if (list == NULL || key == NULL) {
+        return NULL;
+    }
 
     cfl_list_foreach(head, &list->list) {
         pair = cfl_list_entry(head, struct cfl_kvpair, _head);
@@ -341,15 +447,18 @@ struct cfl_variant *cfl_kvlist_fetch_s(struct cfl_kvlist *list, char *key, size_
 int cfl_kvlist_insert_string(struct cfl_kvlist *list,
                              char *key, char *value)
 {
-    int key_len;
-    int val_len;
+    size_t key_len;
+    size_t val_len;
 
-    if (!key || !value) {
+    if (!list || !key || !value) {
         return -1;
     }
 
     key_len = strlen(key);
     val_len = strlen(value);
+    if (key_len > INT_MAX || val_len > INT_MAX) {
+        return -1;
+    }
 
     return cfl_kvlist_insert_string_s(list, key, key_len, value, val_len, CFL_FALSE);
 }
@@ -358,78 +467,126 @@ int cfl_kvlist_insert_bytes(struct cfl_kvlist *list,
                             char *key, char *value,
                             size_t length, int referenced)
 {
+    if (!list || !key || (value == NULL && length > 0)) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_bytes_s(list, key, strlen(key), value, length, referenced);
 }
 
 int cfl_kvlist_insert_reference(struct cfl_kvlist *list,
                                 char *key, void *value)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_reference_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_bool(struct cfl_kvlist *list,
                            char *key, int value)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_bool_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_int64(struct cfl_kvlist *list,
                             char *key, int64_t value)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_int64_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_uint64(struct cfl_kvlist *list,
                             char *key, uint64_t value)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_uint64_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_double(struct cfl_kvlist *list,
                              char *key, double value)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_double_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_array(struct cfl_kvlist *list,
                             char *key, struct cfl_array *value)
 {
+    if (!list || !key || !value) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_array_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert_new_array(struct cfl_kvlist *list,
                                 char *key, size_t size)
 {
+    if (!list || !key) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_new_array_s(list, key, strlen(key), size);
 }
 
 int cfl_kvlist_insert_kvlist(struct cfl_kvlist *list,
                              char *key, struct cfl_kvlist *value)
 {
+    if (!list || !key || !value) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_kvlist_s(list, key, strlen(key), value);
 }
 
 int cfl_kvlist_insert(struct cfl_kvlist *list,
                       char *key, struct cfl_variant *value)
 {
+    if (!list || !key || !value) {
+        return -1;
+    }
+
     return cfl_kvlist_insert_s(list, key, strlen(key), value);
 }
 
 struct cfl_variant *cfl_kvlist_fetch(struct cfl_kvlist *list, char *key)
 {
+    if (!list || !key) {
+        return NULL;
+    }
+
     return cfl_kvlist_fetch_s(list, key, strlen(key));
 }
 
 int cfl_kvlist_count(struct cfl_kvlist *list)
 {
+    if (list == NULL) {
+        return 0;
+    }
+
     return cfl_list_size(&list->list);
 }
 
 int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
 {
-    size_t size;
-    size_t i;
-    int ret = -1;
+    size_t key_size;
+    int printed;
+    int ret = 0;
 
     struct cfl_list *head = NULL;
     struct cfl_kvpair *pair = NULL;
@@ -438,8 +595,7 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
         return -1;
     }
 
-    size = (size_t)cfl_kvlist_count(list);
-    i = 0;
+    printed = CFL_FALSE;
     fputs("{", fp);
     cfl_list_foreach(head, &list->list) {
         pair = cfl_list_entry(head, struct cfl_kvpair, _head);
@@ -447,13 +603,23 @@ int cfl_kvlist_print(FILE *fp, struct cfl_kvlist *list)
             continue;
         }
 
-        fprintf(fp, "\"%s\":", pair->key);
-        ret = cfl_variant_print(fp, pair->val);
-
-        i++;
-        if (i != size) {
+        if (printed) {
             fputs(",", fp);
         }
+
+        key_size = cfl_sds_len(pair->key);
+        ret = print_json_string(fp, pair->key, key_size);
+        if (ret < 0) {
+            return -1;
+        }
+
+        fputs(":", fp);
+        ret = cfl_variant_print(fp, pair->val);
+        if (ret < 0) {
+            return -1;
+        }
+
+        printed = CFL_TRUE;
     }
     fputs("}", fp);
 
@@ -464,6 +630,10 @@ int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name)
 {
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
+
+    if (kvlist == NULL || name == NULL) {
+        return CFL_FALSE;
+    }
 
     cfl_list_foreach(iterator, &kvlist->list) {
         pair = cfl_list_entry(iterator,
@@ -483,6 +653,10 @@ int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name)
     struct cfl_list   *iterator_backup;
     struct cfl_list   *iterator;
     struct cfl_kvpair *pair;
+
+    if (kvlist == NULL || name == NULL) {
+        return CFL_FALSE;
+    }
 
     cfl_list_foreach_safe(iterator, iterator_backup, &kvlist->list) {
         pair = cfl_list_entry(iterator,
@@ -515,4 +689,3 @@ void cfl_kvpair_destroy(struct cfl_kvpair *pair)
         free(pair);
     }
 }
-

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -416,18 +416,21 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    if (cfl_container_variant_contains_kvlist(value, list)) {
-        return -1;
-    }
+    /* Only container-valued variants can participate in container cycles. */
+    if (value->type == CFL_VARIANT_ARRAY || value->type == CFL_VARIANT_KVLIST) {
+        if (cfl_container_variant_contains_kvlist(value, list)) {
+            return -1;
+        }
 
-    if (value->type == CFL_VARIANT_ARRAY &&
-        cfl_container_kvlist_contains_array(list, value->data.as_array)) {
-        return -1;
-    }
+        if (value->type == CFL_VARIANT_ARRAY &&
+            cfl_container_kvlist_contains_array(list, value->data.as_array)) {
+            return -1;
+        }
 
-    if (value->type == CFL_VARIANT_KVLIST &&
-        cfl_container_kvlist_contains_kvlist(list, value->data.as_kvlist)) {
-        return -1;
+        if (value->type == CFL_VARIANT_KVLIST &&
+            cfl_container_kvlist_contains_kvlist(list, value->data.as_kvlist)) {
+            return -1;
+        }
     }
 
     pair = malloc(sizeof(struct cfl_kvpair));

--- a/src/cfl_object.c
+++ b/src/cfl_object.c
@@ -18,6 +18,7 @@
  */
 
 #include "cfl/cfl.h"
+#include <cfl/cfl_container.h>
 
 /* CFL Object
  * ==========
@@ -43,6 +44,151 @@ struct cfl_object *cfl_object_create()
     return o;
 }
 
+static int reuses_current_root(struct cfl_object *o, int type, void *ptr)
+{
+    if (o->variant == NULL) {
+        return CFL_FALSE;
+    }
+
+    if (type == CFL_OBJECT_KVLIST &&
+        o->variant->type == CFL_VARIANT_KVLIST &&
+        o->variant->data.as_kvlist == ptr) {
+        return CFL_TRUE;
+    }
+
+    if (type == CFL_OBJECT_ARRAY &&
+        o->variant->type == CFL_VARIANT_ARRAY &&
+        o->variant->data.as_array == ptr) {
+        return CFL_TRUE;
+    }
+
+    if (type == CFL_OBJECT_VARIANT && o->variant == ptr) {
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+static int kvlist_contains_current(struct cfl_kvlist *kvlist,
+                                   struct cfl_variant *current)
+{
+    if (cfl_container_kvlist_contains_variant(kvlist, current)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_KVLIST &&
+        cfl_container_kvlist_contains_kvlist(kvlist,
+                                             current->data.as_kvlist)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_ARRAY &&
+        cfl_container_kvlist_contains_array(kvlist,
+                                            current->data.as_array)) {
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+static int array_contains_current(struct cfl_array *array,
+                                  struct cfl_variant *current)
+{
+    if (cfl_container_array_contains_variant(array, current)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_KVLIST &&
+        cfl_container_array_contains_kvlist(array,
+                                            current->data.as_kvlist)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_ARRAY &&
+        cfl_container_array_contains_array(array,
+                                           current->data.as_array)) {
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+static int variant_contains_current(struct cfl_variant *variant,
+                                    struct cfl_variant *current)
+{
+    if (cfl_container_variant_contains_variant(variant, current)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_KVLIST &&
+        cfl_container_variant_contains_kvlist(variant,
+                                              current->data.as_kvlist)) {
+        return CFL_TRUE;
+    }
+
+    if (current->type == CFL_VARIANT_ARRAY &&
+        cfl_container_variant_contains_array(variant,
+                                             current->data.as_array)) {
+        return CFL_TRUE;
+    }
+
+    return CFL_FALSE;
+}
+
+static int current_contains_candidate(struct cfl_variant *current,
+                                      int type, void *ptr)
+{
+    struct cfl_variant *variant;
+
+    if (type == CFL_OBJECT_KVLIST) {
+        return cfl_container_variant_contains_kvlist(current, ptr);
+    }
+
+    if (type == CFL_OBJECT_ARRAY) {
+        return cfl_container_variant_contains_array(current, ptr);
+    }
+
+    if (type == CFL_OBJECT_VARIANT) {
+        variant = ptr;
+
+        if (cfl_container_variant_contains_variant(current, variant)) {
+            return CFL_TRUE;
+        }
+
+        if (variant->type == CFL_VARIANT_KVLIST &&
+            cfl_container_variant_contains_kvlist(current,
+                                                  variant->data.as_kvlist)) {
+            return CFL_TRUE;
+        }
+
+        if (variant->type == CFL_VARIANT_ARRAY &&
+            cfl_container_variant_contains_array(current,
+                                                 variant->data.as_array)) {
+            return CFL_TRUE;
+        }
+    }
+
+    return CFL_FALSE;
+}
+
+static int candidate_contains_current(struct cfl_variant *current,
+                                      int type, void *ptr)
+{
+    if (type == CFL_OBJECT_KVLIST) {
+        return kvlist_contains_current(ptr, current);
+    }
+
+    if (type == CFL_OBJECT_ARRAY) {
+        return array_contains_current(ptr, current);
+    }
+
+    if (type == CFL_OBJECT_VARIANT) {
+        return variant_contains_current(ptr, current);
+    }
+
+    return CFL_FALSE;
+}
+
 /*
  * Associate a CFL data type to the object. We only support kvlist, array and variant. Note
  * that everything is held as a variant internally.
@@ -53,6 +199,18 @@ int cfl_object_set(struct cfl_object *o, int type, void *ptr)
 
     if (!o || !ptr) {
         return -1;
+    }
+
+    if (o->variant != NULL) {
+        if (reuses_current_root(o, type, ptr)) {
+            o->type = type;
+            return 0;
+        }
+
+        if (current_contains_candidate(o->variant, type, ptr) ||
+            candidate_contains_current(o->variant, type, ptr)) {
+            return -1;
+        }
     }
 
     if (type == CFL_OBJECT_KVLIST) {

--- a/src/cfl_object.c
+++ b/src/cfl_object.c
@@ -49,32 +49,44 @@ struct cfl_object *cfl_object_create()
  */
 int cfl_object_set(struct cfl_object *o, int type, void *ptr)
 {
-    if (!o) {
+    struct cfl_variant *variant;
+
+    if (!o || !ptr) {
         return -1;
     }
 
     if (type == CFL_OBJECT_KVLIST) {
-        o->type = CFL_OBJECT_KVLIST;
-        o->variant = cfl_variant_create_from_kvlist(ptr);
+        variant = cfl_variant_create_from_kvlist(ptr);
     }
     else if (type == CFL_OBJECT_VARIANT) {
-        o->type = CFL_OBJECT_VARIANT;
-        o->variant = ptr;
+        variant = ptr;
     }
     else if (type == CFL_OBJECT_ARRAY) {
-        o->type = CFL_OBJECT_ARRAY;
-        o->variant = cfl_variant_create_from_array(ptr);
+        variant = cfl_variant_create_from_array(ptr);
     }
     else {
         return -1;
     }
+
+    if (variant == NULL) {
+        return -1;
+    }
+
+    if (o->variant != NULL && o->variant != variant) {
+        cfl_variant_destroy(o->variant);
+    }
+
+    o->type = type;
+    o->variant = variant;
 
     return 0;
 }
 
 int cfl_object_print(FILE *stream, struct cfl_object *o)
 {
-    if (!o) {
+    int ret;
+
+    if (stream == NULL || o == NULL) {
         return -1;
     }
 
@@ -82,8 +94,14 @@ int cfl_object_print(FILE *stream, struct cfl_object *o)
         return -1;
     }
 
-    cfl_variant_print(stream, o->variant);
-    printf("\n");
+    ret = cfl_variant_print(stream, o->variant);
+    if (ret < 0) {
+        return -1;
+    }
+
+    if (fputc('\n', stream) == EOF) {
+        return -1;
+    }
 
     return 0;
 }

--- a/src/cfl_sds.c
+++ b/src/cfl_sds.c
@@ -187,8 +187,13 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
 {
     size_t avail;
     size_t append_len;
+    size_t source_offset;
+    uintptr_t buffer_addr;
+    uintptr_t source_addr;
     struct cfl_sds *head;
     cfl_sds_t tmp = NULL;
+    const char *source;
+    int source_in_buffer;
 
     if (s == NULL || str == NULL || len < 0) {
         return NULL;
@@ -204,6 +209,28 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
         return NULL;
     }
 
+    source = str;
+    source_in_buffer = 0;
+    source_offset = 0;
+
+    /*
+     * This flat-address check lets self-appends survive realloc. If the
+     * source starts inside the SDS buffer, the whole source slice must also
+     * fit in that allocation.
+     */
+    buffer_addr = (uintptr_t) s;
+    source_addr = (uintptr_t) str;
+    if (source_addr >= buffer_addr &&
+        (source_addr - buffer_addr) <= head->alloc) {
+        source_offset = (size_t) (source_addr - buffer_addr);
+
+        if (append_len - 1 > head->alloc - source_offset) {
+            return NULL;
+        }
+
+        source_in_buffer = 1;
+    }
+
     avail = cfl_sds_avail(s);
     if (avail < append_len) {
         tmp = cfl_sds_increase(s, append_len - avail);
@@ -213,12 +240,16 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
         s = tmp;
     }
 
+    if (source_in_buffer) {
+        source = s + source_offset;
+    }
+
     head = CFL_SDS_HEADER(s);
     if (head->len > UINT64_MAX - append_len) {
         return NULL;
     }
 
-    memcpy((char *) (s + head->len), str, append_len);
+    memmove((char *) (s + head->len), source, append_len);
 
     head->len += append_len;
     s[head->len] = '\0';

--- a/src/cfl_sds.c
+++ b/src/cfl_sds.c
@@ -27,12 +27,18 @@
 #include <string.h>
 #include <stdarg.h>
 #include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
 
 #include <cfl/cfl_sds.h>
 
 size_t cfl_sds_avail(cfl_sds_t s)
 {
     struct cfl_sds *h;
+
+    if (s == NULL) {
+        return 0;
+    }
 
     h = CFL_SDS_HEADER(s);
     return (size_t) (h->alloc - h->len);
@@ -43,6 +49,10 @@ static cfl_sds_t sds_alloc(size_t size)
     void *buf;
     cfl_sds_t s;
     struct cfl_sds *head;
+
+    if (size > SIZE_MAX - CFL_SDS_HEADER_SIZE - 1) {
+        return NULL;
+    }
 
     buf = malloc(CFL_SDS_HEADER_SIZE + size + 1);
     if (!buf) {
@@ -61,6 +71,10 @@ static cfl_sds_t sds_alloc(size_t size)
 
 size_t cfl_sds_alloc(cfl_sds_t s)
 {
+    if (s == NULL) {
+        return 0;
+    }
+
     return (size_t) CFL_SDS_HEADER(s)->alloc;
 }
 
@@ -71,9 +85,31 @@ cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len)
     cfl_sds_t out;
     void *tmp;
 
+    if (s == NULL) {
+        return NULL;
+    }
+
     out = s;
-    new_size = (CFL_SDS_HEADER_SIZE + cfl_sds_alloc(s) + len + 1);
     head = CFL_SDS_HEADER(s);
+
+    if (len == 0) {
+        return s;
+    }
+
+    if (head->alloc > UINT64_MAX - len) {
+        return NULL;
+    }
+
+    if (cfl_sds_alloc(s) > SIZE_MAX - len) {
+        return NULL;
+    }
+
+    new_size = cfl_sds_alloc(s) + len;
+    if (new_size > SIZE_MAX - CFL_SDS_HEADER_SIZE - 1) {
+        return NULL;
+    }
+    new_size += CFL_SDS_HEADER_SIZE + 1;
+
     tmp = realloc(head, new_size);
     if (!tmp) {
         return NULL;
@@ -87,6 +123,10 @@ cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len)
 
 size_t cfl_sds_len(cfl_sds_t s)
 {
+    if (s == NULL) {
+        return 0;
+    }
+
     return (size_t) CFL_SDS_HEADER(s)->len;
 }
 
@@ -94,6 +134,10 @@ cfl_sds_t cfl_sds_create_len(const char *str, int len)
 {
     cfl_sds_t s;
     struct cfl_sds *head;
+
+    if (len < 0) {
+        return NULL;
+    }
 
     s = sds_alloc(len);
     if (!s) {
@@ -119,9 +163,12 @@ cfl_sds_t cfl_sds_create(const char *str)
     }
     else {
         len = strlen(str);
+        if (len > INT_MAX) {
+            return NULL;
+        }
     }
 
-    return cfl_sds_create_len(str, len);
+    return cfl_sds_create_len(str, (int) len);
 }
 
 void cfl_sds_destroy(cfl_sds_t s)
@@ -139,21 +186,41 @@ void cfl_sds_destroy(cfl_sds_t s)
 cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
 {
     size_t avail;
+    size_t append_len;
     struct cfl_sds *head;
     cfl_sds_t tmp = NULL;
 
+    if (s == NULL || str == NULL || len < 0) {
+        return NULL;
+    }
+
+    if (len == 0) {
+        return s;
+    }
+
+    append_len = (size_t) len;
+    head = CFL_SDS_HEADER(s);
+    if (head->len > head->alloc || head->len > SIZE_MAX - append_len - 1) {
+        return NULL;
+    }
+
     avail = cfl_sds_avail(s);
-    if (avail < len) {
-        tmp = cfl_sds_increase(s, len);
+    if (avail < append_len) {
+        tmp = cfl_sds_increase(s, append_len - avail);
         if (!tmp) {
             return NULL;
         }
         s = tmp;
     }
-    memcpy((char *) (s + cfl_sds_len(s)), str, len);
 
     head = CFL_SDS_HEADER(s);
-    head->len += len;
+    if (head->len > UINT64_MAX - append_len) {
+        return NULL;
+    }
+
+    memcpy((char *) (s + head->len), str, append_len);
+
+    head->len += append_len;
     s[head->len] = '\0';
 
     return s;
@@ -168,13 +235,26 @@ void cfl_sds_set_len(cfl_sds_t s, size_t len)
 {
     struct cfl_sds *head;
 
+    if (s == NULL) {
+        return;
+    }
+
     head = CFL_SDS_HEADER(s);
+    if (len > head->alloc) {
+        return;
+    }
+
     head->len = len;
+    s[len] = '\0';
 }
 
 void cfl_sds_cat_safe(cfl_sds_t *buf, const char *str, int len)
 {
     cfl_sds_t tmp;
+
+    if (buf == NULL || *buf == NULL) {
+        return;
+    }
 
     tmp = cfl_sds_cat(*buf, str, len);
     if (!tmp) {
@@ -186,51 +266,54 @@ void cfl_sds_cat_safe(cfl_sds_t *buf, const char *str, int len)
 cfl_sds_t cfl_sds_printf(cfl_sds_t *sds, const char *fmt, ...)
 {
     va_list ap;
-    int len = strlen(fmt)*2;
+    size_t avail;
+    size_t growth;
+    size_t base_len;
     int size;
     cfl_sds_t tmp = NULL;
     cfl_sds_t s;
     struct cfl_sds *head;
 
-    if (len < 64) len = 64;
-
-    s = *sds;
-    if (cfl_sds_avail(s)< len) {
-        tmp = cfl_sds_increase(s, len);
-        if (!tmp) {
-            return NULL;
-        }
-        *sds = s = tmp;
-    }
-
-    va_start(ap, fmt);
-    size = vsnprintf((char *) (s + cfl_sds_len(s)), cfl_sds_avail(s), fmt, ap);
-    if (size < 0) {
-        va_end(ap);
+    if (sds == NULL || *sds == NULL || fmt == NULL) {
         return NULL;
     }
-    va_end(ap);
 
-    if (size >= cfl_sds_avail(s)) {
-        tmp = cfl_sds_increase(s, size - cfl_sds_avail(s) + 1);
+    s = *sds;
+    base_len = cfl_sds_len(s);
+    if (base_len > cfl_sds_alloc(s)) {
+        return NULL;
+    }
+
+    while (1) {
+        avail = cfl_sds_avail(s);
+        va_start(ap, fmt);
+        size = vsnprintf((char *) (s + base_len), avail + 1, fmt, ap);
+        va_end(ap);
+
+        if (size < 0) {
+            return NULL;
+        }
+
+        if ((size_t) size <= avail) {
+            break;
+        }
+
+        growth = (size_t) size - avail;
+        tmp = cfl_sds_increase(s, growth);
         if (!tmp) {
             return NULL;
         }
-        *sds = s = tmp;
 
-        va_start(ap, fmt);
-        size = vsnprintf((char *) (s + cfl_sds_len(s)), cfl_sds_avail(s), fmt, ap);
-        if (size > cfl_sds_avail(s)) {
-            va_end(ap);
-            return NULL;
-        }
-        va_end(ap);
+        *sds = s = tmp;
     }
 
     head = CFL_SDS_HEADER(s);
-    head->len += size;
+    if (head->len > UINT64_MAX - (size_t) size) {
+        return NULL;
+    }
+
+    head->len += (size_t) size;
     s[head->len] = '\0';
 
     return s;
 }
-

--- a/src/cfl_utils.c
+++ b/src/cfl_utils.c
@@ -280,13 +280,19 @@ static struct cfl_list *split(const char *line, int separator, int max_split, in
          * and last entry.
          */
         if (count >= max_split && max_split > 0 && i < len) {
-          new = calloc(1, sizeof(struct cfl_split_entry));
+            new = calloc(1, sizeof(struct cfl_split_entry));
             if (!new) {
                 cfl_errno();
                 cfl_utils_split_free(list);
                 return NULL;
             }
             new->value = cfl_string_copy_substr(line, i, len);
+            if (new->value == NULL) {
+                cfl_errno();
+                free(new);
+                cfl_utils_split_free(list);
+                return NULL;
+            }
             new->len   = len - i;
             cfl_list_add(&new->_head, list);
             break;

--- a/src/cfl_utils.c
+++ b/src/cfl_utils.c
@@ -19,15 +19,28 @@
 
 #include <cfl/cfl.h>
 
+#include <limits.h>
+#include <stdint.h>
+
 /* Lookup char into string, return position
  * Based on monkey/monkey's mk_string_char_search.
  */
 static int cfl_string_char_search(const char *string, int c, int len)
 {
     char *p;
+    size_t string_len;
+
+    if (string == NULL) {
+        return -1;
+    }
 
     if (len < 0) {
-        len = strlen(string);
+        string_len = strlen(string);
+        if (string_len > INT_MAX) {
+            return -1;
+        }
+
+        len = (int) string_len;
     }
 
     p = memchr(string, c, len);
@@ -43,14 +56,20 @@ static int cfl_string_char_search(const char *string, int c, int len)
  */
 static char *cfl_string_copy_substr(const char *string, int pos_init, int pos_end)
 {
-    unsigned int size, bytes;
+    size_t size;
+    size_t bytes;
     char *buffer = 0;
 
-    if (pos_init > pos_end) {
+    if (string == NULL || pos_init < 0 || pos_end < 0 || pos_init > pos_end) {
         return NULL;
     }
 
-    size = (unsigned int) (pos_end - pos_init) + 1;
+    bytes = (size_t) (pos_end - pos_init);
+    if (bytes > SIZE_MAX - 1) {
+        return NULL;
+    }
+
+    size = bytes + 1;
     if (size <= 2) {
         size = 4;
     }
@@ -61,7 +80,6 @@ static char *cfl_string_copy_substr(const char *string, int pos_init, int pos_en
         return NULL;
     }
 
-    bytes = pos_end - pos_init;
     memcpy(buffer, string + pos_init, bytes);
     buffer[bytes] = '\0';
 
@@ -74,7 +92,13 @@ static char *cfl_string_copy_substr(const char *string, int pos_init, int pos_en
 static int quoted_string_len(const char *str)
 {
     int len = 0;
-    char quote = *str++; /* Consume the quote character. */
+    char quote;
+
+    if (str == NULL) {
+        return -1;
+    }
+
+    quote = *str++; /* Consume the quote character. */
 
     while (quote != 0) {
         char c = *str++;
@@ -98,6 +122,9 @@ static int quoted_string_len(const char *str)
             default:
                 break;
         }
+        if (len == INT_MAX) {
+            return -1;
+        }
         len++;
     }
 
@@ -117,10 +144,15 @@ static int quoted_string_len(const char *str)
 static int next_token(const char *str, int separator, char **out, int *out_len, int parse_quotes) {
     const char *token_in = str;
     char *token_out;
+    size_t token_len;
     int next_separator = 0;
     int quote = 0; /* Parser state: 0 not inside quoted string, or '"' or '\'' when inside quoted string. */
     int len = 0;
     int i;
+
+    if (str == NULL || out == NULL || out_len == NULL) {
+        return -1;
+    }
 
     /* Skip leading separators. */
     while (*token_in == separator) {
@@ -129,7 +161,12 @@ static int next_token(const char *str, int separator, char **out, int *out_len, 
 
     /* Should quotes be parsed? Or is token quoted? If not, copy until separator or the end of string. */
     if (parse_quotes == CFL_FALSE || (*token_in != '"' && *token_in != '\'')) {
-        len = (int)strlen(token_in);
+        token_len = strlen(token_in);
+        if (token_len > INT_MAX) {
+            return -1;
+        }
+
+        len = (int) token_len;
         next_separator = cfl_string_char_search(token_in, separator, len);
         if (next_separator > 0) {
             len = next_separator;
@@ -186,6 +223,7 @@ static struct cfl_list *split(const char *line, int separator, int max_split, in
     int val_len;
     int len;
     int end;
+    size_t line_len;
     char *val;
     struct cfl_list *list;
     struct cfl_split_entry *new;
@@ -201,7 +239,13 @@ static struct cfl_list *split(const char *line, int separator, int max_split, in
     }
     cfl_list_init(list);
 
-    len = strlen(line);
+    line_len = strlen(line);
+    if (line_len > INT_MAX) {
+        free(list);
+        return NULL;
+    }
+
+    len = (int) line_len;
     while (i < len) {
         end = next_token(line + i, separator, &val, &val_len, quoted);
         if (end == -1) {
@@ -265,6 +309,10 @@ struct cfl_list *cfl_utils_split(const char *line, int separator, int max_split)
 
 void cfl_utils_split_free_entry(struct cfl_split_entry *entry)
 {
+    if (entry == NULL) {
+        return;
+    }
+
     cfl_list_del(&entry->_head);
     free(entry->value);
     free(entry);
@@ -275,6 +323,10 @@ void cfl_utils_split_free(struct cfl_list *list)
     struct cfl_list *tmp;
     struct cfl_list *head;
     struct cfl_split_entry *entry;
+
+    if (list == NULL) {
+        return;
+    }
 
     cfl_list_foreach_safe(head, tmp, list) {
         entry = cfl_list_entry(head, struct cfl_split_entry, _head);

--- a/src/cfl_variant.c
+++ b/src/cfl_variant.c
@@ -23,11 +23,88 @@
 #include <cfl/cfl_kvlist.h>
 #include <cfl/cfl_compat.h>
 
+#include <limits.h>
+
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #define HEXDUMPFORMAT "%#x"
 #else
 #define HEXDUMPFORMAT "%p"
 #endif
+
+static int print_json_string(FILE *fp, const char *str, size_t len)
+{
+    size_t i;
+    size_t written;
+    unsigned char c;
+    int ret;
+
+    if (fputc('"', fp) == EOF) {
+        return -1;
+    }
+    written = 1;
+
+    if (str != NULL) {
+        for (i = 0; i < len; i++) {
+            c = (unsigned char) str[i];
+
+            switch (c) {
+            case '"':
+                ret = fputs("\\\"", fp);
+                written += 2;
+                break;
+            case '\\':
+                ret = fputs("\\\\", fp);
+                written += 2;
+                break;
+            case '\b':
+                ret = fputs("\\b", fp);
+                written += 2;
+                break;
+            case '\f':
+                ret = fputs("\\f", fp);
+                written += 2;
+                break;
+            case '\n':
+                ret = fputs("\\n", fp);
+                written += 2;
+                break;
+            case '\r':
+                ret = fputs("\\r", fp);
+                written += 2;
+                break;
+            case '\t':
+                ret = fputs("\\t", fp);
+                written += 2;
+                break;
+            default:
+                if (c < 0x20) {
+                    ret = fprintf(fp, "\\u%04x", c);
+                    written += 6;
+                }
+                else {
+                    ret = fputc(c, fp);
+                    written++;
+                }
+                break;
+            }
+
+            if (ret < 0) {
+                return -1;
+            }
+        }
+    }
+
+    if (fputc('"', fp) == EOF) {
+        return -1;
+    }
+    written++;
+
+    if (written > INT_MAX) {
+        return INT_MAX;
+    }
+
+    return (int) written;
+}
 
 int cfl_variant_print(FILE *fp, struct cfl_variant *val)
 {
@@ -41,7 +118,10 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
 
     switch (val->type) {
     case CFL_VARIANT_STRING:
-        ret = fprintf(fp, "\"%s\"", val->data.as_string);
+        if (val->data.as_string == NULL && val->size > 0) {
+            return -1;
+        }
+        ret = print_json_string(fp, val->data.as_string, val->size);
         break;
     case CFL_VARIANT_BOOL:
         if (val->data.as_bool) {
@@ -64,9 +144,17 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
         ret = fprintf(fp, "null");
         break;
     case CFL_VARIANT_BYTES:
-        size = cfl_sds_len(val->data.as_bytes);
-        for (i=0; i<size; i++) {
+        if (val->data.as_bytes == NULL && val->size > 0) {
+            return -1;
+        }
+
+        size = val->size;
+        ret = 0;
+        for (i = 0; i < size; i++) {
             ret = fprintf(fp, "%02x", (unsigned char)val->data.as_bytes[i]);
+            if (ret < 0) {
+                return -1;
+            }
         }
         break;
 
@@ -91,17 +179,26 @@ struct cfl_variant *cfl_variant_create_from_string_s(char *value, size_t value_s
 {
     struct cfl_variant *instance;
 
+    if (value == NULL && value_size > 0) {
+        return NULL;
+    }
+
     instance = cfl_variant_create();
     if (!instance) {
         return NULL;
     }
-    instance->referenced = referenced;
+    instance->referenced = referenced ? CFL_TRUE : CFL_FALSE;
 
     if (referenced) {
         instance->data.as_string = value;
     }
     else {
-        instance->data.as_string = cfl_sds_create_len(value, value_size);
+        if (value_size > INT_MAX) {
+            free(instance);
+            return NULL;
+        }
+
+        instance->data.as_string = cfl_sds_create_len(value, (int) value_size);
         if (instance->data.as_string == NULL) {
             free(instance);
             return NULL;
@@ -116,6 +213,10 @@ struct cfl_variant *cfl_variant_create_from_string_s(char *value, size_t value_s
 
 struct cfl_variant *cfl_variant_create_from_string(char *value)
 {
+    if (value == NULL) {
+        return NULL;
+    }
+
     return cfl_variant_create_from_string_s(value, strlen(value), CFL_FALSE);
 }
 
@@ -123,17 +224,26 @@ struct cfl_variant *cfl_variant_create_from_bytes(char *value, size_t length, in
 {
     struct cfl_variant *instance;
 
+    if (value == NULL && length > 0) {
+        return NULL;
+    }
+
     instance = cfl_variant_create();
     if (!instance){
         return NULL;
     }
-    instance->referenced = referenced;
+    instance->referenced = referenced ? CFL_TRUE : CFL_FALSE;
 
     if (referenced) {
         instance->data.as_bytes = value;
     }
     else {
-        instance->data.as_bytes = cfl_sds_create_len(value, length);
+        if (length > INT_MAX) {
+            free(instance);
+            return NULL;
+        }
+
+        instance->data.as_bytes = cfl_sds_create_len(value, (int) length);
         if (instance->data.as_bytes == NULL) {
             free(instance);
             return NULL;
@@ -286,10 +396,18 @@ void cfl_variant_destroy(struct cfl_variant *instance)
 
 void cfl_variant_size_set(struct cfl_variant *var, size_t size)
 {
+    if (var == NULL) {
+        return;
+    }
+
     var->size = size;
 }
 
 size_t cfl_variant_size_get(struct cfl_variant *var)
 {
+    if (var == NULL) {
+        return 0;
+    }
+
     return var->size;
 }

--- a/src/cfl_variant.c
+++ b/src/cfl_variant.c
@@ -24,12 +24,19 @@
 #include <cfl/cfl_compat.h>
 
 #include <limits.h>
-
-#if defined(__MINGW32__) || defined(__MINGW64__)
-#define HEXDUMPFORMAT "%#x"
-#else
-#define HEXDUMPFORMAT "%p"
+#include <math.h>
+#if defined(_MSC_VER)
+#include <float.h>
 #endif
+
+static int double_is_finite(double value)
+{
+#if defined(_MSC_VER)
+    return _finite(value);
+#else
+    return isfinite(value);
+#endif
+}
 
 static int print_json_string(FILE *fp, const char *str, size_t len)
 {
@@ -138,7 +145,12 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
         ret = fprintf(fp, "%" PRIu64, val->data.as_uint64);
         break;
     case CFL_VARIANT_DOUBLE:
-        ret = fprintf(fp, "%lf", val->data.as_double);
+        if (!double_is_finite(val->data.as_double)) {
+            ret = fputs("null", fp);
+        }
+        else {
+            ret = fprintf(fp, "%lf", val->data.as_double);
+        }
         break;
     case CFL_VARIANT_NULL:
         ret = fprintf(fp, "null");
@@ -159,7 +171,7 @@ int cfl_variant_print(FILE *fp, struct cfl_variant *val)
         break;
 
     case CFL_VARIANT_REFERENCE:
-        ret = fprintf(fp, HEXDUMPFORMAT, val->data.as_reference);
+        ret = fputs("null", fp);
         break;
     case CFL_VARIANT_ARRAY:
         ret = cfl_array_print(fp, val->data.as_array);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PUBLIC_HEADERS
   cfl_atomic.h
   cfl_checksum.h
   cfl_compat.h
+  cfl_container.h
   cfl_found.h
   cfl_hash.h
   cfl_info.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(lib/acutest)
 
 set(UNIT_TESTS_FILES
+  atomic_operations.c
   kv.c
   kvlist.c
   array.c
@@ -12,6 +13,10 @@ set(UNIT_TESTS_FILES
   version.c
   utils.c
   )
+
+if(NOT CFL_SYSTEM_WINDOWS)
+  find_package(Threads REQUIRED)
+endif()
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cfl_tests_internal.h.in"
@@ -27,6 +32,10 @@ foreach(source_file ${UNIT_TESTS_FILES})
     ${source_file}
     )
   target_link_libraries(${source_file_we} cfl-static)
+
+  if(source_file STREQUAL "atomic_operations.c" AND NOT CFL_SYSTEM_WINDOWS)
+    target_link_libraries(${source_file_we} Threads::Threads)
+  endif()
 
   if (CFL_SANITIZE_ADDRESS)
     add_sanitizers(${source_file_we})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ include_directories(lib/acutest)
 
 set(UNIT_TESTS_FILES
   atomic_operations.c
+  checksum.c
+  headers.c
   kv.c
   kvlist.c
   array.c
@@ -17,6 +19,27 @@ set(UNIT_TESTS_FILES
 if(NOT CFL_SYSTEM_WINDOWS)
   find_package(Threads REQUIRED)
 endif()
+
+set(PUBLIC_HEADERS
+  cfl.h
+  cfl_array.h
+  cfl_atomic.h
+  cfl_checksum.h
+  cfl_compat.h
+  cfl_found.h
+  cfl_hash.h
+  cfl_info.h
+  cfl_kv.h
+  cfl_kvlist.h
+  cfl_list.h
+  cfl_log.h
+  cfl_object.h
+  cfl_sds.h
+  cfl_time.h
+  cfl_utils.h
+  cfl_variant.h
+  cfl_version.h
+  )
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cfl_tests_internal.h.in"
@@ -42,4 +65,24 @@ foreach(source_file ${UNIT_TESTS_FILES})
   endif()
 
   add_test(${source_file_we} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${source_file_we})
+endforeach()
+
+foreach(public_header ${PUBLIC_HEADERS})
+  string(REPLACE "." "_" public_header_target ${public_header})
+  set(public_header_source "${CMAKE_CURRENT_BINARY_DIR}/header_${public_header_target}.c")
+  file(WRITE "${public_header_source}" "#include <cfl/${public_header}>\nint main(void) { return 0; }\n")
+
+  add_executable(
+    cfl-test-header-${public_header_target}
+    ${public_header_source}
+    )
+
+  target_link_libraries(cfl-test-header-${public_header_target} cfl-static)
+
+  if (CFL_SANITIZE_ADDRESS)
+    add_sanitizers(cfl-test-header-${public_header_target})
+  endif()
+
+  add_test(cfl-test-header-${public_header_target}
+           ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cfl-test-header-${public_header_target})
 endforeach()

--- a/tests/array.c
+++ b/tests/array.c
@@ -362,6 +362,28 @@ static void append_variant_rejects_cycles()
     cfl_variant_destroy(variant);
 }
 
+static void append_rejects_duplicate_variant()
+{
+    int ret;
+    struct cfl_array *arr;
+    struct cfl_variant *variant;
+
+    arr = cfl_array_create(2);
+    TEST_CHECK(arr != NULL);
+
+    variant = cfl_variant_create_from_string("value");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_array_append(arr, variant);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_array_append(arr, variant);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(cfl_array_size(arr) == 1);
+
+    cfl_array_destroy(arr);
+}
+
 static void append_kvlist_rejects_cycles()
 {
     int ret;
@@ -512,6 +534,7 @@ TEST_LIST = {
     {"append_kvlist",       append_kvlist},
     {"append_array_rejects_cycles", append_array_rejects_cycles},
     {"append_variant_rejects_cycles", append_variant_rejects_cycles},
+    {"append_rejects_duplicate_variant", append_rejects_duplicate_variant},
     {"append_kvlist_rejects_cycles", append_kvlist_rejects_cycles},
     {"remove_by_index",     remove_by_index},
     {"remove_by_reference", remove_by_reference},

--- a/tests/array.c
+++ b/tests/array.c
@@ -363,6 +363,44 @@ static void remove_by_reference()
     cfl_array_destroy(arr);
 }
 
+static void null_inputs()
+{
+    int ret;
+    struct cfl_variant *var;
+
+    TEST_CHECK(cfl_array_size(NULL) == 0);
+
+    var = cfl_array_fetch_by_index(NULL, 0);
+    TEST_CHECK(var == NULL);
+
+    ret = cfl_array_resizable(NULL, CFL_TRUE);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append(NULL, NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append_string(NULL, "value");
+    TEST_CHECK(ret < 0);
+
+    ret = cfl_array_append_string(NULL, NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append_bytes(NULL, NULL, 1, CFL_TRUE);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append_array(NULL, NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append_kvlist(NULL, NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_remove_by_index(NULL, 0);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_remove_by_reference(NULL, NULL);
+    TEST_CHECK(ret == -1);
+}
+
 TEST_LIST = {
     {"create",              create},
     {"resizable",           resizable},
@@ -382,5 +420,6 @@ TEST_LIST = {
     {"append_kvlist",       append_kvlist},
     {"remove_by_index",     remove_by_index},
     {"remove_by_reference", remove_by_reference},
+    {"null_inputs",         null_inputs},
     { 0 }
 };

--- a/tests/array.c
+++ b/tests/array.c
@@ -317,6 +317,72 @@ static void append_kvlist()
     cfl_array_destroy(arr);
 }
 
+static void append_array_rejects_cycles()
+{
+    int ret;
+    struct cfl_array *arr;
+    struct cfl_array *child;
+
+    arr = cfl_array_create(2);
+    TEST_CHECK(arr != NULL);
+
+    ret = cfl_array_append_array(arr, arr);
+    TEST_CHECK(ret == -1);
+
+    child = cfl_array_create(1);
+    TEST_CHECK(child != NULL);
+
+    ret = cfl_array_append_array(arr, child);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_array_append_array(arr, child);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_array_append_array(child, arr);
+    TEST_CHECK(ret == -1);
+
+    cfl_array_destroy(arr);
+}
+
+static void append_variant_rejects_cycles()
+{
+    int ret;
+    struct cfl_array *arr;
+    struct cfl_variant *variant;
+
+    arr = cfl_array_create(1);
+    TEST_CHECK(arr != NULL);
+
+    variant = cfl_variant_create_from_array(arr);
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_array_append(arr, variant);
+    TEST_CHECK(ret == -1);
+
+    cfl_variant_destroy(variant);
+}
+
+static void append_kvlist_rejects_cycles()
+{
+    int ret;
+    struct cfl_array *arr;
+    struct cfl_kvlist *kvlist;
+
+    arr = cfl_array_create(1);
+    TEST_CHECK(arr != NULL);
+
+    kvlist = cfl_kvlist_create();
+    TEST_CHECK(kvlist != NULL);
+
+    ret = cfl_array_append_kvlist(arr, kvlist);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_kvlist_insert_array(kvlist, "cycle", arr);
+    TEST_CHECK(ret == -1);
+
+    cfl_array_destroy(arr);
+}
+
 static void remove_by_index()
 {
     int ret;
@@ -361,6 +427,32 @@ static void remove_by_reference()
     TEST_CHECK(var == NULL);
 
     cfl_array_destroy(arr);
+}
+
+static void print_write_error()
+{
+#ifdef __linux__
+    int ret;
+    FILE *fp;
+    struct cfl_array *arr;
+
+    arr = cfl_array_create(0);
+    TEST_CHECK(arr != NULL);
+
+    fp = fopen("/dev/full", "w");
+    if (fp == NULL) {
+        cfl_array_destroy(arr);
+        return;
+    }
+
+    setvbuf(fp, NULL, _IONBF, 0);
+
+    ret = cfl_array_print(fp, arr);
+    TEST_CHECK(ret == -1);
+
+    fclose(fp);
+    cfl_array_destroy(arr);
+#endif
 }
 
 static void null_inputs()
@@ -418,8 +510,12 @@ TEST_LIST = {
     {"append_array",        append_array},
     {"append_new_array",    append_new_array},
     {"append_kvlist",       append_kvlist},
+    {"append_array_rejects_cycles", append_array_rejects_cycles},
+    {"append_variant_rejects_cycles", append_variant_rejects_cycles},
+    {"append_kvlist_rejects_cycles", append_kvlist_rejects_cycles},
     {"remove_by_index",     remove_by_index},
     {"remove_by_reference", remove_by_reference},
+    {"print_write_error",   print_write_error},
     {"null_inputs",         null_inputs},
     { 0 }
 };

--- a/tests/atomic_operations.c
+++ b/tests/atomic_operations.c
@@ -33,6 +33,13 @@
 
 static uint64_t global_counter;
 
+static void test_atomic_initialize()
+{
+    TEST_CHECK(cfl_atomic_initialize() == 0);
+    TEST_CHECK(cfl_atomic_initialize() == 0);
+    TEST_CHECK(cfl_init() == 0);
+}
+
 static void test_atomic_basic_operations()
 {
     TEST_CHECK(cfl_init() == 0);
@@ -45,6 +52,29 @@ static void test_atomic_basic_operations()
 
     TEST_CHECK(cfl_atomic_compare_exchange(&global_counter, 10, 20) == 1);
     TEST_CHECK(cfl_atomic_load(&global_counter) == 20);
+}
+
+static void test_atomic_full_width_values()
+{
+    uint64_t value;
+    uint64_t high_bit;
+
+    high_bit = UINT64_C(1) << 63;
+
+    TEST_CHECK(cfl_atomic_initialize() == 0);
+
+    value = 0;
+    cfl_atomic_store(&value, UINT64_MAX);
+    TEST_CHECK(cfl_atomic_load(&value) == UINT64_MAX);
+
+    TEST_CHECK(cfl_atomic_compare_exchange(&value, high_bit, 1) == 0);
+    TEST_CHECK(cfl_atomic_load(&value) == UINT64_MAX);
+
+    TEST_CHECK(cfl_atomic_compare_exchange(&value, UINT64_MAX, high_bit) == 1);
+    TEST_CHECK(cfl_atomic_load(&value) == high_bit);
+
+    TEST_CHECK(cfl_atomic_compare_exchange(&value, high_bit, 0) == 1);
+    TEST_CHECK(cfl_atomic_load(&value) == 0);
 }
 
 static void add_through_compare_exchange(uint64_t val)
@@ -139,7 +169,9 @@ static void test_atomic_operations()
 #endif
 
 TEST_LIST = {
+    { "atomic_initialize", test_atomic_initialize },
     { "atomic_basic_operations", test_atomic_basic_operations },
+    { "atomic_full_width_values", test_atomic_full_width_values },
     { "atomic_operations", test_atomic_operations },
     { 0 }
 };

--- a/tests/atomic_operations.c
+++ b/tests/atomic_operations.c
@@ -1,0 +1,145 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CFL
+ *  ===
+ *  Copyright (C) 2022 The CFL Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cfl/cfl.h>
+
+#if defined (_WIN32) || defined (_WIN64)
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+#include "cfl_tests_internal.h"
+
+#define THREAD_COUNT   100
+#define CYCLE_COUNT    10000
+#define EXPECTED_VALUE (THREAD_COUNT * CYCLE_COUNT)
+
+static uint64_t global_counter;
+
+static void test_atomic_basic_operations()
+{
+    TEST_CHECK(cfl_init() == 0);
+
+    cfl_atomic_store(&global_counter, 10);
+    TEST_CHECK(cfl_atomic_load(&global_counter) == 10);
+
+    TEST_CHECK(cfl_atomic_compare_exchange(&global_counter, 5, 20) == 0);
+    TEST_CHECK(cfl_atomic_load(&global_counter) == 10);
+
+    TEST_CHECK(cfl_atomic_compare_exchange(&global_counter, 10, 20) == 1);
+    TEST_CHECK(cfl_atomic_load(&global_counter) == 20);
+}
+
+static void add_through_compare_exchange(uint64_t val)
+{
+    uint64_t old;
+    uint64_t new;
+    int      result;
+
+    do {
+        old = cfl_atomic_load(&global_counter);
+        new = old + val;
+
+        result = cfl_atomic_compare_exchange(&global_counter, old, new);
+    }
+    while (result == 0);
+}
+
+#if defined (_WIN32) || defined (_WIN64)
+static DWORD WINAPI worker_thread_add_through_compare_exchange(LPVOID ptr)
+#else
+static void *worker_thread_add_through_compare_exchange(void *ptr)
+#endif
+{
+    int local_counter;
+
+    (void) ptr;
+
+    for (local_counter = 0; local_counter < CYCLE_COUNT; local_counter++) {
+        add_through_compare_exchange(1);
+    }
+
+#if defined (_WIN32) || defined (_WIN64)
+    return 0;
+#else
+    return NULL;
+#endif
+}
+
+#if defined (_WIN32) || defined (_WIN64)
+
+static void test_atomic_operations()
+{
+    HANDLE threads[THREAD_COUNT];
+    DWORD  thread_ids[THREAD_COUNT];
+    int    thread_index;
+    DWORD  result;
+
+    TEST_CHECK(cfl_init() == 0);
+
+    cfl_atomic_store(&global_counter, 0);
+
+    for (thread_index = 0; thread_index < THREAD_COUNT; thread_index++) {
+        threads[thread_index] = CreateThread(NULL, 0,
+                                             worker_thread_add_through_compare_exchange,
+                                             NULL, 0, &thread_ids[thread_index]);
+    }
+
+    for (thread_index = 0; thread_index < THREAD_COUNT; thread_index++) {
+        result = WaitForSingleObject(threads[thread_index], INFINITE);
+        TEST_CHECK(result == WAIT_OBJECT_0);
+        CloseHandle(threads[thread_index]);
+    }
+
+    TEST_CHECK(cfl_atomic_load(&global_counter) == EXPECTED_VALUE);
+}
+
+#else
+
+static void test_atomic_operations()
+{
+    pthread_t threads[THREAD_COUNT];
+    int       thread_index;
+    int       result;
+
+    TEST_CHECK(cfl_init() == 0);
+
+    cfl_atomic_store(&global_counter, 0);
+
+    for (thread_index = 0; thread_index < THREAD_COUNT; thread_index++) {
+        result = pthread_create(&threads[thread_index], NULL,
+                                worker_thread_add_through_compare_exchange, NULL);
+        TEST_CHECK(result == 0);
+    }
+
+    for (thread_index = 0; thread_index < THREAD_COUNT; thread_index++) {
+        result = pthread_join(threads[thread_index], NULL);
+        TEST_CHECK(result == 0);
+    }
+
+    TEST_CHECK(cfl_atomic_load(&global_counter) == EXPECTED_VALUE);
+}
+#endif
+
+TEST_LIST = {
+    { "atomic_basic_operations", test_atomic_basic_operations },
+    { "atomic_operations", test_atomic_operations },
+    { 0 }
+};

--- a/tests/checksum.c
+++ b/tests/checksum.c
@@ -17,12 +17,22 @@
  *  limitations under the License.
  */
 
-#ifndef CFL_CHECKSUM_H
-#define CFL_CHECKSUM_H
+#include <cfl/cfl_checksum.h>
 
-#include <stddef.h>
-#include <stdint.h>
+#include "cfl_tests_internal.h"
 
-uint32_t cfl_checksum_crc32c(unsigned char *buffer, size_t length);
+static void crc32c_null_input()
+{
+    uint32_t crc;
 
-#endif
+    crc = cfl_checksum_crc32c(NULL, 0);
+    TEST_CHECK(crc == 0);
+
+    crc = cfl_checksum_crc32c(NULL, 1);
+    TEST_CHECK(crc == 0);
+}
+
+TEST_LIST = {
+    {"crc32c_null_input", crc32c_null_input},
+    { 0 }
+};

--- a/tests/headers.c
+++ b/tests/headers.c
@@ -17,12 +17,33 @@
  *  limitations under the License.
  */
 
-#ifndef CFL_CHECKSUM_H
-#define CFL_CHECKSUM_H
+#include <cfl/cfl_array.h>
+#include <cfl/cfl_atomic.h>
+#include <cfl/cfl_checksum.h>
+#include <cfl/cfl_compat.h>
+#include <cfl/cfl_found.h>
+#include <cfl/cfl_hash.h>
+#include <cfl/cfl_info.h>
+#include <cfl/cfl_kv.h>
+#include <cfl/cfl_kvlist.h>
+#include <cfl/cfl_list.h>
+#include <cfl/cfl_log.h>
+#include <cfl/cfl_object.h>
+#include <cfl/cfl_sds.h>
+#include <cfl/cfl_time.h>
+#include <cfl/cfl_utils.h>
+#include <cfl/cfl_variant.h>
+#include <cfl/cfl_version.h>
+#include <cfl/cfl.h>
 
-#include <stddef.h>
-#include <stdint.h>
+#include "cfl_tests_internal.h"
 
-uint32_t cfl_checksum_crc32c(unsigned char *buffer, size_t length);
+static void public_headers_compile()
+{
+    TEST_CHECK(cfl_found() == 0);
+}
 
-#endif
+TEST_LIST = {
+    {"public_headers_compile", public_headers_compile},
+    { 0 }
+};

--- a/tests/kv.c
+++ b/tests/kv.c
@@ -76,7 +76,30 @@ static void regular_operation()
     cfl_kv_release(&entry_list);
 }
 
+static void null_inputs()
+{
+    struct cfl_kv *entry;
+
+    cfl_kv_init(NULL);
+
+    entry = cfl_kv_item_create(NULL, "key", "value");
+    TEST_CHECK(entry == NULL);
+
+    entry = cfl_kv_item_create_len(NULL, "key", 3, "value", 5);
+    TEST_CHECK(entry == NULL);
+
+    entry = cfl_kv_item_create_len(NULL, "key", 3, NULL, 1);
+    TEST_CHECK(entry == NULL);
+
+    TEST_CHECK(cfl_kv_get_key_value(NULL, NULL) == NULL);
+    TEST_CHECK(cfl_kv_get_key_value("key", NULL) == NULL);
+
+    cfl_kv_item_destroy(NULL);
+    cfl_kv_release(NULL);
+}
+
 TEST_LIST = {
     {"regular_operation",  regular_operation},
+    {"null_inputs",  null_inputs},
     { 0 }
 };

--- a/tests/kvlist.c
+++ b/tests/kvlist.c
@@ -1378,6 +1378,28 @@ static void reject_variant_cycles()
     cfl_variant_destroy(variant);
 }
 
+static void reject_duplicate_variant()
+{
+    int ret;
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    variant = cfl_variant_create_from_string("value");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_kvlist_insert(list, "one", variant);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_kvlist_insert(list, "two", variant);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(cfl_kvlist_count(list) == 1);
+
+    cfl_kvlist_destroy(list);
+}
+
 static void reject_array_cycles()
 {
     int ret;
@@ -1432,6 +1454,7 @@ TEST_LIST = {
     {"print_write_error", print_write_error},
     {"reject_kvlist_cycles", reject_kvlist_cycles},
     {"reject_variant_cycles", reject_variant_cycles},
+    {"reject_duplicate_variant", reject_duplicate_variant},
     {"reject_array_cycles", reject_array_cycles},
     { 0 }
 };

--- a/tests/kvlist.c
+++ b/tests/kvlist.c
@@ -24,6 +24,30 @@
 
 #include "cfl_tests_internal.h"
 
+static int compare(FILE *fp, char *expect)
+{
+    size_t len;
+    size_t ret_fp;
+    char buf[256] = {0};
+
+    len = strlen(expect);
+
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        return -1;
+    }
+
+    ret_fp = fread(&buf[0], 1, sizeof(buf) - 1, fp);
+    if (ret_fp == 0 && ferror(fp)) {
+        return -1;
+    }
+
+    if (strlen(buf) != len) {
+        return -1;
+    }
+
+    return strncmp(expect, &buf[0], len);
+}
+
 static void create_destroy()
 {
     struct cfl_kvlist *list = NULL;
@@ -1166,6 +1190,82 @@ static void test_basics()
     cfl_kvlist_destroy(list);
 }
 
+static void null_inputs()
+{
+    int ret;
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    cfl_kvlist_destroy(NULL);
+
+    ret = cfl_kvlist_count(NULL);
+    TEST_CHECK(ret == 0);
+
+    variant = cfl_kvlist_fetch(NULL, "key");
+    TEST_CHECK(variant == NULL);
+
+    variant = cfl_kvlist_fetch_s(NULL, "key", 3);
+    TEST_CHECK(variant == NULL);
+
+    ret = cfl_kvlist_contains(NULL, "key");
+    TEST_CHECK(ret == CFL_FALSE);
+
+    ret = cfl_kvlist_remove(NULL, "key");
+    TEST_CHECK(ret == CFL_FALSE);
+
+    ret = cfl_kvlist_insert_string(NULL, "key", "value");
+    TEST_CHECK(ret == -1);
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, NULL, "value");
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_kvlist_insert_bytes(list, "key", NULL, 1, CFL_TRUE);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_kvlist_insert_array(list, "key", NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_kvlist_insert_kvlist(list, "key", NULL);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_kvlist_insert(list, "key", NULL);
+    TEST_CHECK(ret == -1);
+
+    variant = cfl_kvlist_fetch(list, NULL);
+    TEST_CHECK(variant == NULL);
+
+    cfl_kvpair_destroy(NULL);
+    cfl_kvlist_destroy(list);
+}
+
+static void print_escaped_keys()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_kvlist *list;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, "a\"b\n", "v\n");
+    TEST_CHECK(ret == 0);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_kvlist_print(fp, list);
+    TEST_CHECK(ret > 0);
+
+    ret = compare(fp, "{\"a\\\"b\\n\":\"v\\n\"}");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_kvlist_destroy(list);
+}
+
 TEST_LIST = {
     {"create_destroy",  create_destroy},
     {"count", count},
@@ -1193,5 +1293,7 @@ TEST_LIST = {
     {"insert_empty_array_s", insert_empty_array_s},
     {"insert_empty_kvlist_s", insert_empty_kvlist_s},
     {"basics", test_basics},
+    {"null_inputs", null_inputs},
+    {"print_escaped_keys", print_escaped_keys},
     { 0 }
 };

--- a/tests/kvlist.c
+++ b/tests/kvlist.c
@@ -1266,6 +1266,139 @@ static void print_escaped_keys()
     cfl_kvlist_destroy(list);
 }
 
+static void embedded_nul_keys_do_not_match_short_name()
+{
+    int ret;
+    char key[] = {'a', 'd', 'm', 'i', 'n', '\0', 'x'};
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, "admin", "plain");
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_kvlist_insert_string_s(list, key, sizeof(key),
+                                     "hidden", 6, CFL_FALSE);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_kvlist_contains(list, "admin");
+    TEST_CHECK(ret == CFL_TRUE);
+
+    ret = cfl_kvlist_remove(list, "admin");
+    TEST_CHECK(ret == CFL_TRUE);
+
+    ret = cfl_kvlist_count(list);
+    TEST_CHECK(ret == 1);
+
+    variant = cfl_kvlist_fetch_s(list, key, sizeof(key));
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_kvlist_contains(list, "admin");
+    TEST_CHECK(ret == CFL_FALSE);
+
+    ret = cfl_kvlist_remove(list, "admin");
+    TEST_CHECK(ret == CFL_FALSE);
+
+    ret = cfl_kvlist_count(list);
+    TEST_CHECK(ret == 1);
+
+    cfl_kvlist_destroy(list);
+}
+
+static void print_write_error()
+{
+#ifdef __linux__
+    int ret;
+    FILE *fp;
+    struct cfl_kvlist *list;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    fp = fopen("/dev/full", "w");
+    if (fp == NULL) {
+        cfl_kvlist_destroy(list);
+        return;
+    }
+
+    setvbuf(fp, NULL, _IONBF, 0);
+
+    ret = cfl_kvlist_print(fp, list);
+    TEST_CHECK(ret == -1);
+
+    fclose(fp);
+    cfl_kvlist_destroy(list);
+#endif
+}
+
+static void reject_kvlist_cycles()
+{
+    int ret;
+    struct cfl_kvlist *list;
+    struct cfl_kvlist *child;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_kvlist(list, "self", list);
+    TEST_CHECK(ret == -1);
+
+    child = cfl_kvlist_create();
+    TEST_CHECK(child != NULL);
+
+    ret = cfl_kvlist_insert_kvlist(list, "child", child);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_kvlist_insert_kvlist(list, "child-again", child);
+    TEST_CHECK(ret == -1);
+
+    ret = cfl_kvlist_insert_kvlist(child, "parent", list);
+    TEST_CHECK(ret == -1);
+
+    cfl_kvlist_destroy(list);
+}
+
+static void reject_variant_cycles()
+{
+    int ret;
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    variant = cfl_variant_create_from_kvlist(list);
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_kvlist_insert(list, "self", variant);
+    TEST_CHECK(ret == -1);
+
+    cfl_variant_destroy(variant);
+}
+
+static void reject_array_cycles()
+{
+    int ret;
+    struct cfl_array *array;
+    struct cfl_kvlist *list;
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    array = cfl_array_create(1);
+    TEST_CHECK(array != NULL);
+
+    ret = cfl_kvlist_insert_array(list, "array", array);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_array_append_kvlist(array, list);
+    TEST_CHECK(ret == -1);
+
+    cfl_kvlist_destroy(list);
+}
+
 TEST_LIST = {
     {"create_destroy",  create_destroy},
     {"count", count},
@@ -1295,5 +1428,10 @@ TEST_LIST = {
     {"basics", test_basics},
     {"null_inputs", null_inputs},
     {"print_escaped_keys", print_escaped_keys},
+    {"embedded_nul_keys_do_not_match_short_name", embedded_nul_keys_do_not_match_short_name},
+    {"print_write_error", print_write_error},
+    {"reject_kvlist_cycles", reject_kvlist_cycles},
+    {"reject_variant_cycles", reject_variant_cycles},
+    {"reject_array_cycles", reject_array_cycles},
     { 0 }
 };

--- a/tests/object.c
+++ b/tests/object.c
@@ -21,6 +21,30 @@
 #include <cfl/cfl.h>
 #include "cfl_tests_internal.h"
 
+static int compare(FILE *fp, char *expect)
+{
+    size_t len;
+    size_t ret_fp;
+    char buf[128] = {0};
+
+    len = strlen(expect);
+
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        return -1;
+    }
+
+    ret_fp = fread(&buf[0], 1, sizeof(buf) - 1, fp);
+    if (ret_fp == 0 && ferror(fp)) {
+        return -1;
+    }
+
+    if (strlen(buf) != len) {
+        return -1;
+    }
+
+    return strncmp(expect, &buf[0], len);
+}
+
 static void test_basics()
 {
     int ret;
@@ -52,7 +76,46 @@ static void test_basics()
     cfl_object_destroy(object);
 }
 
+static void test_replace_and_print()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_variant *variant;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    variant = cfl_variant_create_from_string("first");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_object_set(object, CFL_OBJECT_VARIANT, variant);
+    TEST_CHECK(ret == 0);
+
+    variant = cfl_variant_create_from_string("second");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_object_set(object, CFL_OBJECT_VARIANT, variant);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_VARIANT, NULL);
+    TEST_CHECK(ret == -1);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "\"second\"\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
 TEST_LIST = {
     { "test_basics", test_basics },
+    { "test_replace_and_print", test_replace_and_print },
     { 0 }
 };

--- a/tests/object.c
+++ b/tests/object.c
@@ -114,8 +114,204 @@ static void test_replace_and_print()
     cfl_object_destroy(object);
 }
 
+static void test_reuse_owned_kvlist()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_kvlist *list;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, "key", "value");
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_KVLIST, list);
+    TEST_CHECK(ret == 0);
+
+    list = object->variant->data.as_kvlist;
+
+    ret = cfl_object_set(object, CFL_OBJECT_KVLIST, list);
+    TEST_CHECK(ret == 0);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "{\"key\":\"value\"}\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
+static void test_reuse_owned_array()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_array *array;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    array = cfl_array_create(1);
+    TEST_CHECK(array != NULL);
+
+    ret = cfl_array_append_string(array, "value");
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_ARRAY, array);
+    TEST_CHECK(ret == 0);
+
+    array = object->variant->data.as_array;
+
+    ret = cfl_object_set(object, CFL_OBJECT_ARRAY, array);
+    TEST_CHECK(ret == 0);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "[\"value\"]\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
+static void test_reject_nested_kvlist_reuse()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_kvlist *outer;
+    struct cfl_kvlist *inner;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    outer = cfl_kvlist_create();
+    TEST_CHECK(outer != NULL);
+
+    inner = cfl_kvlist_create();
+    TEST_CHECK(inner != NULL);
+
+    ret = cfl_kvlist_insert_kvlist(outer, "child", inner);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_KVLIST, outer);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_KVLIST, inner);
+    TEST_CHECK(ret == -1);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "{\"child\":{}}\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
+static void test_reject_nested_array_reuse()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_array *outer;
+    struct cfl_array *inner;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    outer = cfl_array_create(1);
+    TEST_CHECK(outer != NULL);
+
+    inner = cfl_array_create(0);
+    TEST_CHECK(inner != NULL);
+
+    ret = cfl_array_append_array(outer, inner);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_ARRAY, outer);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_ARRAY, inner);
+    TEST_CHECK(ret == -1);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "[[]]\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
+static void test_reject_nested_variant_reuse()
+{
+    int ret;
+    FILE *fp;
+    struct cfl_object *object;
+    struct cfl_kvlist *list;
+    struct cfl_variant *variant;
+
+    object = cfl_object_create();
+    TEST_CHECK(object != NULL);
+
+    list = cfl_kvlist_create();
+    TEST_CHECK(list != NULL);
+
+    ret = cfl_kvlist_insert_string(list, "key", "value");
+    TEST_CHECK(ret == 0);
+
+    variant = cfl_kvlist_fetch(list, "key");
+    TEST_CHECK(variant != NULL);
+
+    ret = cfl_object_set(object, CFL_OBJECT_KVLIST, list);
+    TEST_CHECK(ret == 0);
+
+    ret = cfl_object_set(object, CFL_OBJECT_VARIANT, variant);
+    TEST_CHECK(ret == -1);
+
+    fp = tmpfile();
+    TEST_CHECK(fp != NULL);
+
+    ret = cfl_object_print(fp, object);
+    TEST_CHECK(ret == 0);
+
+    ret = compare(fp, "{\"key\":\"value\"}\n");
+    TEST_CHECK(ret == 0);
+
+    fclose(fp);
+    cfl_object_destroy(object);
+}
+
 TEST_LIST = {
     { "test_basics", test_basics },
     { "test_replace_and_print", test_replace_and_print },
+    { "test_reuse_owned_kvlist", test_reuse_owned_kvlist },
+    { "test_reuse_owned_array", test_reuse_owned_array },
+    { "test_reject_nested_kvlist_reuse", test_reject_nested_kvlist_reuse },
+    { "test_reject_nested_array_reuse", test_reject_nested_array_reuse },
+    { "test_reject_nested_variant_reuse", test_reject_nested_variant_reuse },
     { 0 }
 };

--- a/tests/sds.c
+++ b/tests/sds.c
@@ -52,8 +52,46 @@ static void test_sds_printf()
     cfl_sds_destroy(s);
 }
 
+static void test_sds_invalid_inputs()
+{
+    cfl_sds_t s;
+    cfl_sds_t tmp;
+
+    tmp = cfl_sds_create_len("x", -1);
+    TEST_CHECK(tmp == NULL);
+
+    s = cfl_sds_create("test");
+    TEST_CHECK(s != NULL);
+    TEST_CHECK(cfl_sds_len(s) == 4);
+
+    tmp = cfl_sds_cat(s, "x", -1);
+    TEST_CHECK(tmp == NULL);
+    TEST_CHECK(cfl_sds_len(s) == 4);
+
+    tmp = cfl_sds_cat(NULL, "x", 1);
+    TEST_CHECK(tmp == NULL);
+
+    tmp = cfl_sds_cat(s, NULL, 1);
+    TEST_CHECK(tmp == NULL);
+    TEST_CHECK(cfl_sds_len(s) == 4);
+
+    cfl_sds_set_len(s, 100);
+    TEST_CHECK(cfl_sds_len(s) == 4);
+
+    tmp = cfl_sds_printf(NULL, "%s", "x");
+    TEST_CHECK(tmp == NULL);
+
+    tmp = cfl_sds_printf(&s, NULL);
+    TEST_CHECK(tmp == NULL);
+    TEST_CHECK(cfl_sds_len(s) == 4);
+
+    cfl_sds_cat_safe(NULL, "x", 1);
+    cfl_sds_destroy(s);
+}
+
 TEST_LIST = {
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
+    { "sds_invalid_inputs", test_sds_invalid_inputs},
     { 0 }
 };

--- a/tests/sds.c
+++ b/tests/sds.c
@@ -89,9 +89,45 @@ static void test_sds_invalid_inputs()
     cfl_sds_destroy(s);
 }
 
+static void test_sds_self_append()
+{
+    cfl_sds_t s;
+    cfl_sds_t tmp;
+
+    s = cfl_sds_create("abcdef");
+    TEST_CHECK(s != NULL);
+
+    tmp = cfl_sds_cat(s, s, cfl_sds_len(s));
+    TEST_CHECK(tmp != NULL);
+    s = tmp;
+
+    TEST_CHECK(cfl_sds_len(s) == 12);
+    TEST_CHECK(strcmp("abcdefabcdef", s) == 0);
+
+    cfl_sds_destroy(s);
+}
+
+static void test_sds_rejects_oversized_in_buffer_slice()
+{
+    cfl_sds_t s;
+    cfl_sds_t tmp;
+
+    s = cfl_sds_create("abcdef");
+    TEST_CHECK(s != NULL);
+
+    tmp = cfl_sds_cat(s, s + 4, 4);
+    TEST_CHECK(tmp == NULL);
+    TEST_CHECK(cfl_sds_len(s) == 6);
+    TEST_CHECK(strcmp("abcdef", s) == 0);
+
+    cfl_sds_destroy(s);
+}
+
 TEST_LIST = {
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
     { "sds_invalid_inputs", test_sds_invalid_inputs},
+    { "sds_self_append", test_sds_self_append},
+    { "sds_rejects_oversized_in_buffer_slice", test_sds_rejects_oversized_in_buffer_slice},
     { 0 }
 };

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -153,10 +153,25 @@ void test_cfl_utils_split_quoted_errors()
     TEST_CHECK(split == NULL);
 }
 
+void test_cfl_utils_null_inputs()
+{
+    struct cfl_list *split = NULL;
+
+    split = cfl_utils_split(NULL, ',', 1);
+    TEST_CHECK(split == NULL);
+
+    split = cfl_utils_split_quoted(NULL, ',', 1);
+    TEST_CHECK(split == NULL);
+
+    cfl_utils_split_free_entry(NULL);
+    cfl_utils_split_free(NULL);
+}
+
 
 TEST_LIST = {
     { "test_flb_utils_split", test_cfl_utils_split },
     { "test_flb_utils_split_quoted", test_cfl_utils_split_quoted},
     { "test_flb_utils_split_quoted_errors", test_cfl_utils_split_quoted_errors},
+    { "test_cfl_utils_null_inputs", test_cfl_utils_null_inputs},
     { 0 }
 };

--- a/tests/variant.c
+++ b/tests/variant.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include <cfl/cfl.h>
 #include <cfl/cfl_variant.h>
 #include <cfl/cfl_compat.h>
@@ -383,6 +384,48 @@ static void test_variant_print_double()
     }
 }
 
+static void test_variant_print_nonfinite_double()
+{
+    int ret;
+    int i;
+    double inputs[] = {HUGE_VAL, -HUGE_VAL, HUGE_VAL - HUGE_VAL};
+    char *expect = "null";
+
+    FILE *fp = NULL;
+    struct cfl_variant *val = NULL;
+
+    for (i=0; i<sizeof(inputs)/sizeof(double); i++) {
+        fp = tmpfile();
+        if (!TEST_CHECK(fp != NULL)) {
+            TEST_MSG("%d: fp is NULL", i);
+            continue;
+        }
+
+        val = cfl_variant_create_from_double(inputs[i]);
+        if (!TEST_CHECK(val != NULL)) {
+            TEST_MSG("%d: cfl_variant_create_from_double failed", i);
+            fclose(fp);
+            continue;
+        }
+
+        ret = cfl_variant_print(fp, val);
+        if (!TEST_CHECK(ret > 0)) {
+            TEST_MSG("%d:cfl_variant_print failed", i);
+            cfl_variant_destroy(val);
+            fclose(fp);
+            continue;
+        }
+
+        ret = compare(fp, expect, 0);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("%d:compare failed", i);
+        }
+
+        cfl_variant_destroy(val);
+        fclose(fp);
+    }
+}
+
 static void test_variant_print_string()
 {
     int ret;
@@ -628,7 +671,7 @@ static void test_variant_print_reference()
 {
     int ret;
     int *input = (int*)0x12345678;
-    char expect[] = "0x12345678";
+    char expect[] = "null";
 
     FILE *fp = NULL;
     struct cfl_variant *val = NULL;
@@ -703,6 +746,7 @@ TEST_LIST = {
     {"variant_print_int64", test_variant_print_int64},
     {"variant_print_uint64", test_variant_print_uint64},
     {"variant_print_double", test_variant_print_double},
+    {"variant_print_nonfinite_double", test_variant_print_nonfinite_double},
     {"variant_print_string", test_variant_print_string},
     {"variant_print_string_s", test_variant_print_string_s},
     {"variant_print_sized_string_without_nul", test_variant_print_sized_string_without_nul},

--- a/tests/variant.c
+++ b/tests/variant.c
@@ -409,7 +409,7 @@ static void test_variant_print_nonfinite_double()
         }
 
         ret = cfl_variant_print(fp, val);
-        if (!TEST_CHECK(ret > 0)) {
+        if (!TEST_CHECK(ret != EOF)) {
             TEST_MSG("%d:cfl_variant_print failed", i);
             cfl_variant_destroy(val);
             fclose(fp);
@@ -690,7 +690,7 @@ static void test_variant_print_reference()
     }
 
     ret = cfl_variant_print(fp, val);
-    if (!TEST_CHECK(ret > 0)) {
+    if (!TEST_CHECK(ret != EOF)) {
         TEST_MSG("cfl_variant_print failed");
         fclose(fp);
         cfl_variant_destroy(val);

--- a/tests/variant.c
+++ b/tests/variant.c
@@ -472,6 +472,68 @@ static void test_variant_print_string_s()
     }
 }
 
+static void test_variant_print_sized_string_without_nul()
+{
+    int ret;
+    char input[] = {'a', 'b', 'c', 'd'};
+    char *expect = "\"ab\"";
+    FILE *fp = NULL;
+    struct cfl_variant *val = NULL;
+
+    fp = tmpfile();
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fp is NULL");
+        return;
+    }
+
+    val = cfl_variant_create_from_string_s(input, 2, CFL_TRUE);
+    if (!TEST_CHECK(val != NULL)) {
+        TEST_MSG("cfl_variant_create_from_string_s failed");
+        fclose(fp);
+        return;
+    }
+
+    ret = cfl_variant_print(fp, val);
+    TEST_CHECK(ret > 0);
+
+    ret = compare(fp, expect, 0);
+    TEST_CHECK(ret == 0);
+
+    cfl_variant_destroy(val);
+    fclose(fp);
+}
+
+static void test_variant_print_escaped_string()
+{
+    int ret;
+    char input[] = "line\n\"quoted\"\\";
+    char *expect = "\"line\\n\\\"quoted\\\"\\\\\"";
+    FILE *fp = NULL;
+    struct cfl_variant *val = NULL;
+
+    fp = tmpfile();
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fp is NULL");
+        return;
+    }
+
+    val = cfl_variant_create_from_string(input);
+    if (!TEST_CHECK(val != NULL)) {
+        TEST_MSG("cfl_variant_create_from_string failed");
+        fclose(fp);
+        return;
+    }
+
+    ret = cfl_variant_print(fp, val);
+    TEST_CHECK(ret > 0);
+
+    ret = compare(fp, expect, 0);
+    TEST_CHECK(ret == 0);
+
+    cfl_variant_destroy(val);
+    fclose(fp);
+}
+
 static void test_variant_print_bytes()
 {
     int ret;
@@ -507,6 +569,58 @@ static void test_variant_print_bytes()
     }
     cfl_variant_destroy(val);
     fclose(fp);
+}
+
+static void test_variant_print_referenced_bytes()
+{
+    int ret;
+    char input[] = {0x1f, 0xaa, 0x0a, 0xff};
+    char *expect = "1faa0aff";
+    FILE *fp = NULL;
+    struct cfl_variant *val = NULL;
+
+    fp = tmpfile();
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fp is NULL");
+        return;
+    }
+
+    val = cfl_variant_create_from_bytes(input, 4, CFL_TRUE);
+    if (!TEST_CHECK(val != NULL)) {
+        TEST_MSG("cfl_variant_create_from_bytes failed");
+        fclose(fp);
+        return;
+    }
+
+    ret = cfl_variant_print(fp, val);
+    TEST_CHECK(ret > 0);
+
+    ret = compare(fp, expect, 0);
+    TEST_CHECK(ret == 0);
+
+    cfl_variant_destroy(val);
+    fclose(fp);
+}
+
+static void test_variant_invalid_inputs()
+{
+    struct cfl_variant *val;
+    int ret;
+
+    val = cfl_variant_create_from_string(NULL);
+    TEST_CHECK(val == NULL);
+
+    val = cfl_variant_create_from_string_s(NULL, 1, CFL_FALSE);
+    TEST_CHECK(val == NULL);
+
+    val = cfl_variant_create_from_bytes(NULL, 1, CFL_TRUE);
+    TEST_CHECK(val == NULL);
+
+    TEST_CHECK(cfl_variant_size_get(NULL) == 0);
+    cfl_variant_size_set(NULL, 1);
+
+    ret = cfl_variant_print(NULL, NULL);
+    TEST_CHECK(ret == -1);
 }
 
 
@@ -591,7 +705,11 @@ TEST_LIST = {
     {"variant_print_double", test_variant_print_double},
     {"variant_print_string", test_variant_print_string},
     {"variant_print_string_s", test_variant_print_string_s},
+    {"variant_print_sized_string_without_nul", test_variant_print_sized_string_without_nul},
+    {"variant_print_escaped_string", test_variant_print_escaped_string},
     {"variant_print_bytes", test_variant_print_bytes},
+    {"variant_print_referenced_bytes", test_variant_print_referenced_bytes},
+    {"variant_invalid_inputs", test_variant_invalid_inputs},
     {"variant_print_array", test_variant_print_array},
     {"variant_print_kvlist", test_variant_print_kvlist},
     {"variant_print_reference", test_variant_print_reference},


### PR DESCRIPTION
Port the cmetrics atomic operations interface to CFL with `cfl_atomic_*` names and wire it into the build with compiler-specific backends for GCC, Clang, and MSVC, plus a pthread-based fallback.

This PR also hardens public API input validation, expands regression coverage, documents the top-level CFL interfaces, and updates repository/CI maintenance files needed for the new coverage to run reliably.

**Changes:**
  - Add the `cfl_atomic_*` API and backend selection logic.
  - Add tests for load, store, compare-exchange, and threaded increments.
  - Harden core public API behavior around invalid inputs.
  - Expand `README.md` coverage for the library’s top-level interfaces.
  - Add repository guidance in `AGENTS.md`.
  - Fix CI coverage for Debian Buster archive mirrors, supported Windows runners,
  and code-analysis workflow wiring.

**Validation:**
  - Added unit coverage for the new atomics interface.
  - Verified workflow linting with `actionlint`.
  - Confirmed Debian Buster downstream coverage still applies based on Fluent Bit
  packaging targets.