### PR TITLE
build: publish bundled xxhash dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ set(src
 
 # Static Library
 add_library(cfl-static STATIC ${src})
-target_link_libraries(cfl-static PRIVATE xxhash)
+target_link_libraries(cfl-static PUBLIC xxhash)
 
 if(CFL_ATOMIC_NEEDS_LIBATOMIC)
   target_link_libraries(cfl-static PUBLIC atomic)


### PR DESCRIPTION
cfl_hash.h is a public header and includes xxh3.h from the bundled xxHash dependency. When CFL is consumed via CMake, cfl-static needs to publish the xxhash usage requirements so downstream targets inherit the bundled xxHash include directory.\n\nValidation:\n- cmake -S . -B build-xxhash-include -DCFL_TESTS=On\n- cmake --build build-xxhash-include\n- ctest --output-on-failure