### PR TITLE
arena: add optional allocation context

### DIFF
--- a/ARENA.md
+++ b/ARENA.md
@@ -1,0 +1,260 @@
+# CFL arena allocator
+
+`cfl_arena` is an optional allocator for CFL variants, arrays, key/value lists,
+kvpairs, and owned SDS strings. It reduces allocator traffic when an application
+constructs, mutates, and discards a complete object graph as one unit.
+
+The normal CFL constructors remain heap-backed. Arena use is explicit and does
+not change existing callers.
+
+## When to use an arena
+
+An arena is a good fit when:
+
+- many related CFL values have the same lifetime;
+- the complete graph has a clear owner and reset point;
+- processing finishes before the graph is reset;
+- individual removals do not need to immediately return memory to the system;
+- the arena can be reused across documents or batches.
+
+Examples include a decoded document, a mutable telemetry record, or a batch
+that remains owned through a processor chain and is serialized before reset.
+
+Keep heap allocation when objects have unrelated lifetimes, children move to
+longer-lived owners, memory must be reclaimed individually, or a long-lived
+container experiences unbounded churn.
+
+## Public API
+
+Include the arena interface directly:
+
+```c
+#include <cfl/cfl_arena.h>
+```
+
+It is also included by `<cfl/cfl.h>`.
+
+```c
+struct cfl_arena;
+
+struct cfl_arena *cfl_arena_create(size_t chunk_size);
+struct cfl_arena *cfl_arena_create_ex(size_t chunk_size,
+                                      size_t large_object_threshold);
+void cfl_arena_destroy(struct cfl_arena *arena);
+void cfl_arena_reset(struct cfl_arena *arena);
+
+size_t cfl_arena_bytes_reserved(struct cfl_arena *arena);
+size_t cfl_arena_bytes_used(struct cfl_arena *arena);
+size_t cfl_arena_large_object_threshold(struct cfl_arena *arena);
+
+void cfl_arena_external_cache_limit_set(struct cfl_arena *arena,
+                                        size_t limit);
+size_t cfl_arena_external_cache_limit_get(struct cfl_arena *arena);
+size_t cfl_arena_external_cache_bytes(struct cfl_arena *arena);
+```
+
+Passing zero as `chunk_size` selects the default chunk size. With
+`cfl_arena_create_ex()`, a zero large-object threshold selects the default
+policy derived from the chunk size.
+
+## Arena-aware constructors
+
+The following constructors associate new values with an arena:
+
+```c
+struct cfl_variant *cfl_variant_create_in(struct cfl_arena *arena);
+struct cfl_array *cfl_array_create_in(struct cfl_arena *arena,
+                                      size_t slot_count);
+struct cfl_kvlist *cfl_kvlist_create_in(struct cfl_arena *arena);
+cfl_sds_t cfl_sds_create_len_in(struct cfl_arena *arena,
+                                const char *str, int len);
+```
+
+Typed variant constructors have matching `_in` forms, including strings,
+bytes, booleans, integers, doubles, nulls, references, arrays, and kvlists.
+
+Nested containers can inherit their parent's allocator:
+
+```c
+struct cfl_array *cfl_array_create_like(struct cfl_array *parent,
+                                        size_t slot_count);
+struct cfl_kvlist *cfl_kvlist_create_like(struct cfl_kvlist *parent);
+```
+
+For a heap-backed parent, `create_like()` creates a heap-backed child. For an
+arena-backed parent, it creates the child in the same arena.
+
+## Basic example
+
+```c
+#include <cfl/cfl.h>
+
+int process_batch(void)
+{
+    int result;
+    struct cfl_arena *arena;
+    struct cfl_kvlist *record;
+
+    arena = cfl_arena_create(8192);
+    if (arena == NULL) {
+        return -1;
+    }
+
+    result = 0;
+
+    record = cfl_kvlist_create_in(arena);
+    if (record == NULL) {
+        result = -1;
+        goto done;
+    }
+
+    if (cfl_kvlist_insert_string(record, "message", "ready") != 0 ||
+        cfl_kvlist_insert_int64(record, "status", 200) != 0) {
+        result = -1;
+        goto done;
+    }
+
+    /* Mutate, inspect, or serialize record before resetting the arena. */
+
+done:
+    cfl_arena_destroy(arena);
+
+    return result;
+}
+```
+
+For repeated batches, reuse the arena:
+
+```c
+while (next_batch()) {
+    /* Construct and completely process one graph. */
+    process_with_arena(arena);
+
+    /* Every arena-backed pointer is invalid after this call. */
+    cfl_arena_reset(arena);
+}
+```
+
+## Ownership rules
+
+Arena lifetime is part of object ownership:
+
+- Reset and destruction invalidate every pointer allocated from the arena.
+- Do not retain arena-backed values after reset or destruction.
+- Do not attach values from different arenas to one array or kvlist.
+- Do not mix heap-backed and arena-backed children in the same object graph.
+- Use `create_like()` when constructing nested containers during mutation.
+- A raw array or kvlist must have only one owning variant at a time.
+- If an object must outlive the arena, copy it into its destination allocator
+  before resetting the source arena.
+
+CFL validates allocator ownership for supported container attachments. A
+rejected cross-arena insertion leaves ownership with the caller.
+
+Destroy functions can be used on arena-backed values while the arena is alive.
+They release owned external storage and make reusable internal slots available
+where supported. They do not replace the need to destroy the arena itself.
+
+## Reset and reclamation
+
+`cfl_arena_reset()` prepares the arena for another graph. It invalidates the
+previous graph, resets chunk allocation positions, clears reusable-object
+state, and handles external allocations according to the configured cache.
+
+Removing an individual value does not necessarily reduce reserved memory.
+Chunk storage is reclaimed for reuse at reset, not returned after every object
+destruction. This is the central throughput-versus-retention tradeoff of arena
+allocation.
+
+## Large values and external caching
+
+Small and medium allocations come from arena chunks. Allocations at or above
+the large-object threshold use separately tracked external storage so unusually
+large values do not consume the remainder of a normal chunk.
+
+Reusable external buffers may remain cached after reset. Configure the maximum
+cached capacity with:
+
+```c
+cfl_arena_external_cache_limit_set(arena, limit);
+```
+
+Setting the limit to zero disables external-buffer caching. Reducing the limit
+immediately trims the cache. A larger limit can improve throughput for repeated
+large payloads but may increase retained memory and RSS.
+
+The arena also maintains size classes for commonly-sized owned SDS values.
+Callers do not need to select a class.
+
+## Memory statistics
+
+The statistics API separates live capacity from retained storage:
+
+- `cfl_arena_bytes_used()` reports live arena payload capacity.
+- `cfl_arena_bytes_reserved()` reports memory reserved by chunks and external
+  allocations, including CFL allocation headers but excluding allocator
+  metadata.
+- `cfl_arena_external_cache_bytes()` reports the portion held in the reusable
+  external cache.
+
+Reserved bytes can remain higher than used bytes after removals or reset. Peak
+RSS can also exceed both values because it includes the process, allocator
+metadata, page granularity, and allocator-retained memory.
+
+Measure CPU, peak RSS, reserved bytes, used bytes, and cached bytes when tuning.
+Fewer calls to `malloc()` do not by themselves prove lower memory usage.
+
+## Thread safety
+
+An arena is not thread-safe. All allocation, mutation, destruction, statistic,
+cache-configuration, and reset operations involving the same arena must be
+serialized by the caller.
+
+Separate arenas can be used independently by separate threads as long as their
+object graphs are not mixed.
+
+## Error handling
+
+Arena constructors return `NULL` on invalid input, ownership violations, or
+allocation failure. Container insert operations retain their documented return
+conventions. Check every constructor and insertion before continuing to mutate
+the graph.
+
+An allocation failure does not require abandoning the arena. The caller may
+destroy or reset it normally, provided no partially-created pointer is used.
+
+## Tuning
+
+Start with the default policy:
+
+```c
+arena = cfl_arena_create(0);
+```
+
+Tune only with representative workloads:
+
+1. Choose a chunk size large enough for common graphs without excessive unused
+   capacity.
+2. Keep very large values external so they do not fragment normal chunks.
+3. Bound or disable the external cache when retained memory matters more than
+   repeated large-buffer throughput.
+4. Test multiple payload distributions and mutation patterns.
+5. Compare against the heap implementation rather than assuming the arena wins.
+
+A separate arena per small object is usually counterproductive. Prefer one
+arena for the complete bounded document or batch.
+
+## Benchmarks
+
+Build the supplied benchmark tools with:
+
+```sh
+cmake -S . -B build-bench \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCFL_BENCHMARKS=On
+cmake --build build-bench -j8
+```
+
+See [benchmarks/README.md](benchmarks/README.md) for heap-versus-arena CPU, RSS,
+fragmentation, mutable OTLP-style workloads, and the deterministic payload
+matrix.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CFL_VERSION_STR    "${CFL_VERSION_MAJOR}.${CFL_VERSION_MINOR}.${CFL_VERSION_
 # Configuration options
 option(CFL_DEV                            "Enable development mode"                    No)
 option(CFL_TESTS                          "Enable unit testing"                        No)
+option(CFL_BENCHMARKS                     "Build benchmark tools"                      No)
 option(CFL_INSTALL_BUNDLED_XXHASH_HEADERS "Enable bundled xxHash headers installation" Yes)
 
 if(CFL_DEV)
@@ -143,6 +144,10 @@ set(CFL_BUILD_DIR "${CFL_ROOT}/build")
 # CFL sources
 add_subdirectory(include)
 add_subdirectory(src)
+
+if(CFL_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
 
 # Tests
 if(CFL_TESTS)

--- a/README.md
+++ b/README.md
@@ -1,65 +1,69 @@
 # CFL
 
-CFL is a tiny C library that provides small data-structure and utility
-interfaces. It was originally created to satisfy the needs of Fluent Bit and
-related libraries such as CMetrics and CTraces.
+CFL is a compact C library of data structures and low-level utilities used by
+[Fluent Bit](https://fluentbit.io/) and its companion telemetry libraries. It
+provides dynamic strings, intrusive lists, typed variants, arrays, key/value
+containers, hashing, checksums, atomics, and an optional arena allocator.
 
-Note: The name does not mean anything specific; you can call it `c:\ floppy`
-if you want.
+The library is designed to be embedded. Callers can include the complete public
+interface with:
 
-## Interfaces
+```c
+#include <cfl/cfl.h>
+```
 
-Applications can include `<cfl/cfl.h>` to pull in the common CFL interfaces.
-Specialized headers are also available under `include/cfl/` when a caller only
-needs one module.
+Individual headers under `include/cfl/` can be used when a component needs a
+smaller interface.
 
-### Core
+## Highlights
 
-- `cfl_init()`: initializes library-level facilities.
-- `cfl_version()`: returns the CFL version string.
-- `CFL_TRUE` and `CFL_FALSE`: common boolean-style constants used by CFL APIs.
+- Small C API with no required runtime framework.
+- Typed recursive values through `cfl_variant`, `cfl_array`, and `cfl_kvlist`.
+- Length-aware dynamic strings through `cfl_sds`.
+- Intrusive lists and lightweight string key/value entries.
+- Portable 64-bit atomics and time helpers.
+- xxHash wrappers and CRC32C checksums.
+- Optional arenas for allocation-heavy, bounded object graphs.
+- CMake support for embedding, installation, tests, and benchmarks.
 
-### Data Structures
+## Core data structures
 
-- `cfl_sds`: dynamic string storage with explicit length and allocation
-  tracking. It supports creation from strings or buffers, growth, concatenation,
-  formatted writes, length updates, and destruction.
-- `cfl_list`: intrusive doubly linked list helpers. It provides initialization,
-  add, append, prepend, delete, concatenate, size, entry lookup, and safe
-  iteration macros.
-- `cfl_kv`: SDS-backed string key/value entries stored in a `cfl_list`. This is
-  useful for simple string maps where values are plain strings.
-- `cfl_variant`: tagged value container for bool, signed integer, unsigned
-  integer, double, null, reference, string, bytes, array, and key/value list
-  values.
-- `cfl_array`: ordered collection of `cfl_variant` entries. It supports fixed
-  or resizable arrays, append helpers for all variant types, fetch by index,
-  removal, size inspection, and printing.
-- `cfl_kvlist`: string-keyed map whose values are `cfl_variant` instances. It
-  supports typed insert helpers, size-aware key APIs, fetch, contains, remove,
-  count, and printing.
-- `cfl_object`: generic wrapper that can hold a `cfl_kvlist`, `cfl_variant`, or
-  `cfl_array` and print the associated value.
+| Interface | Purpose |
+| --- | --- |
+| `cfl_sds` | Growable binary-safe strings with explicit length and capacity |
+| `cfl_list` | Intrusive doubly linked lists and safe iteration helpers |
+| `cfl_kv` | String key/value entries stored in a CFL list |
+| `cfl_variant` | Tagged bool, integer, double, null, reference, string, bytes, array, or map value |
+| `cfl_array` | Ordered collection of variants |
+| `cfl_kvlist` | String-keyed map of variants |
+| `cfl_object` | Generic wrapper for a variant, array, or key/value list |
+| `cfl_arena` | Optional shared allocator for bounded CFL object graphs |
 
-### Utilities
+Heap-backed constructors remain the default. Applications that construct and
+discard complete variant graphs can opt into `cfl_arena`; see
+[ARENA.md](ARENA.md) for its ownership model, API, examples, and tuning advice.
 
-- `cfl_atomic`: 64-bit atomic initialization, compare-exchange, store, and load
-  operations with platform-specific backends.
-- `cfl_time`: wall-clock timestamp helper that returns nanoseconds.
-- `cfl_hash`: naming wrappers around xxHash 64-bit and 128-bit hashing APIs.
-- `cfl_checksum`: CRC32C checksum helper.
-- `cfl_utils`: string split helpers, including quote-aware splitting, with
-  results returned as `cfl_list` entries.
-- `cfl_log`: runtime error reporting helpers.
+## Utility interfaces
 
-### Support Headers
+- `cfl_atomic`: 64-bit compare-exchange, store, and load operations with
+  platform-specific backends.
+- `cfl_time`: wall-clock timestamps in nanoseconds.
+- `cfl_hash`: xxHash 64-bit and 128-bit wrappers.
+- `cfl_checksum`: CRC32C checksums.
+- `cfl_utils`: string splitting, including quote-aware parsing.
+- `cfl_log`: runtime error-reporting helpers.
+- `cfl_compat`, `cfl_found`, and `cfl_info`: platform and build integration.
 
-- `cfl_compat`: platform compatibility macros.
-- `cfl_found`: lightweight include-probe helper for parent projects.
-- `cfl_info`: generated build information and feature flags.
-- `cfl_version`: version macros.
+## Build
 
-## Build and Test
+CFL requires CMake 3.20 or newer and a C compiler:
+
+```sh
+cmake -S . -B build
+cmake --build build -j8
+```
+
+To build and run the unit tests:
 
 ```sh
 cmake -S . -B build -DCFL_TESTS=On
@@ -67,10 +71,60 @@ cmake --build build -j8
 ctest --test-dir build --output-on-failure
 ```
 
+Useful configuration options are:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `CFL_DEV` | `No` | Enable the debug development configuration and tests |
+| `CFL_TESTS` | `No` | Build unit and public-header tests |
+| `CFL_BENCHMARKS` | `No` | Build allocation and mutation benchmarks |
+| `CFL_INSTALL_BUNDLED_XXHASH_HEADERS` | `Yes` | Install bundled xxHash headers |
+
+For arena performance and memory comparisons, see
+[benchmarks/README.md](benchmarks/README.md).
+
+## Embedding with CMake
+
+Projects commonly embed CFL with `add_subdirectory` and link the static target:
+
+```cmake
+add_subdirectory(path/to/cfl)
+target_link_libraries(my_target PRIVATE cfl-static)
+```
+
+Applications using installed headers can include either `<cfl/cfl.h>` or the
+specific module headers they require.
+
+## API conventions
+
+- Public functions and types use the `cfl_` prefix.
+- Constructors return `NULL` when allocation or validation fails.
+- Container insertion functions report success or failure and document when
+  ownership transfers to the container.
+- Heap-created values are destroyed through their matching CFL destroy APIs.
+- Arena-created values are invalidated together by arena reset or destruction.
+- An arena is not thread-safe; access to a shared arena must be serialized.
+
+## Documentation
+
+- Public API: the self-contained headers under [`include/cfl/`](include/cfl/)
+  describe each supported interface.
+- Building and embedding: see the build and CMake examples above.
+- Testing: enable `CFL_TESTS` and run the suite through CTest as shown above.
+- Optional arena allocation: see [ARENA.md](ARENA.md) for lifecycle and
+  ownership rules.
+- Performance tools: see [benchmarks/README.md](benchmarks/README.md) for the
+  supplied benchmark programs and measurement guidance.
+
 ## License
 
-This program is under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0).
+CFL is distributed under the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## Authors
 
-Copyright is assigned to the `CFL Authors`, you can see a list of contributors [here](https://github.com/fluent/cfl/graphs/contributors).
+Copyright is assigned to the CFL Authors. The contributor list is available on
+[GitHub](https://github.com/fluent/cfl/graphs/contributors).
+
+The name CFL has no required expansion. Historically, “C floppy” has been used
+as an intentionally playful interpretation.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(cfl-benchmark-variant-arena arena.c)
+target_link_libraries(cfl-benchmark-variant-arena cfl-static)
+
+add_executable(cfl-benchmark-variant-mutable variant_mutable.c)
+target_link_libraries(cfl-benchmark-variant-mutable cfl-static)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,78 @@
+# Variant arena benchmark
+
+Configure a release build and run the heap and arena workloads with identical
+parameters:
+
+```sh
+cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release -DCFL_BENCHMARKS=On
+cmake --build build-bench -j8
+build-bench/benchmarks/cfl-benchmark-variant-arena heap 1000 1000
+build-bench/benchmarks/cfl-benchmark-variant-arena arena 1000 1000 8192
+```
+
+The tool reports elapsed time, peak RSS, glibc heap usage, and arena
+reserved/used bytes. Use `perf stat` for CPU and allocator-independent memory
+events:
+
+```sh
+perf stat -r 5 -e task-clock,cycles,instructions,cache-misses,page-faults \
+  build-bench/benchmarks/cfl-benchmark-variant-arena heap 1000 1000
+perf stat -r 5 -e task-clock,cycles,instructions,cache-misses,page-faults \
+  build-bench/benchmarks/cfl-benchmark-variant-arena arena 1000 1000 8192
+```
+
+For fragmentation analysis, run both modes under heaptrack or Massif. Arena
+slack is the difference between `arena_reserved` and `arena_used` for the last
+constructed graph.
+
+## Mutable OTLP-style logs
+
+The mutable benchmark builds an OTLP JSON-like hierarchy of resource logs,
+scope logs, log records, bodies, and attributes. Each mutation round replaces
+severity and status attributes, appends a record, and removes the oldest one:
+
+```sh
+build-bench/benchmarks/cfl-benchmark-variant-mutable heap 100 100 10
+build-bench/benchmarks/cfl-benchmark-variant-mutable arena 100 100 10 8192
+
+perf stat -r 5 -e task-clock,cycles,instructions,cache-misses,page-faults \
+  build-bench/benchmarks/cfl-benchmark-variant-mutable heap 100 100 10
+perf stat -r 5 -e task-clock,cycles,instructions,cache-misses,page-faults \
+  build-bench/benchmarks/cfl-benchmark-variant-mutable arena 100 100 10 8192
+```
+
+To compare a graph containing approximately 2 MiB of owned log-body strings:
+
+```sh
+build-bench/benchmarks/cfl-benchmark-variant-mutable heap 10 100 10 8192 2097152
+build-bench/benchmarks/cfl-benchmark-variant-mutable arena 10 100 10 8192 2097152
+```
+
+The optional arguments after content size are the large-object threshold and
+payload distribution (`uniform`, `bimodal`, `heavy`, or `random`). A threshold
+of zero selects the default of half the arena chunk size. A very large
+threshold effectively disables external large-object allocation. The final
+optional argument sets the external-buffer cache limit; zero disables caching.
+
+Run the deterministic validation matrix with:
+
+```sh
+benchmarks/run_variant_matrix.sh build-bench > variant-matrix.txt
+awk -f benchmarks/summarize_variant_matrix.awk variant-matrix.txt
+```
+
+It covers zero, 64 KiB, and 2 MiB content; immutable and replacement-heavy
+lifetimes; four size distributions; three chunk sizes; and five large-object
+policies. Output uses one `key=value` record per configuration for mechanical
+comparison. `CFL_MATRIX_ITERATIONS` and `CFL_MATRIX_RECORDS` control runtime.
+
+The arena context is reused and reset between documents. Within one document,
+the workload intentionally exposes growth from logically freed values:
+individual removals do not reclaim arena storage until the next reset or
+destroy.
+
+On glibc, `heap_initial_live` and `heap_final_live` are sampled while the heap
+document is still alive. Compare them with `arena_initial_used` and
+`arena_used`. `max_rss_kb` is process-level high-water RSS and can remain the
+same for small workloads because it is page-granular and includes executable,
+library, and allocator-retained pages.

--- a/benchmarks/arena.c
+++ b/benchmarks/arena.c
@@ -1,0 +1,141 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+#if !defined(CFL_SYSTEM_WINDOWS)
+#include <sys/resource.h>
+#endif
+
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
+#include <cfl/cfl.h>
+
+static uint64_t monotonic_nanoseconds(void)
+{
+    struct timespec now;
+
+    timespec_get(&now, TIME_UTC);
+    return ((uint64_t) now.tv_sec * 1000000000ULL) + now.tv_nsec;
+}
+
+static int build_heap(size_t entries)
+{
+    struct cfl_kvlist *list;
+    size_t index;
+    char key[32];
+
+    list = cfl_kvlist_create();
+    if (list == NULL) {
+        return -1;
+    }
+    for (index = 0; index < entries; index++) {
+        snprintf(key, sizeof(key), "key-%zu", index);
+        if (cfl_kvlist_insert_int64(list, key, (int64_t) index) != 0) {
+            cfl_kvlist_destroy(list);
+            return -1;
+        }
+    }
+    cfl_kvlist_destroy(list);
+    return 0;
+}
+
+static int build_arena(size_t entries, size_t chunk_size,
+                       size_t *reserved, size_t *used)
+{
+    struct cfl_arena *arena;
+    struct cfl_kvlist *list;
+    size_t index;
+    char key[32];
+
+    arena = cfl_arena_create(chunk_size);
+    if (arena == NULL) {
+        return -1;
+    }
+    list = cfl_kvlist_create_in(arena);
+    if (list == NULL) {
+        cfl_arena_destroy(arena);
+        return -1;
+    }
+    for (index = 0; index < entries; index++) {
+        snprintf(key, sizeof(key), "key-%zu", index);
+        if (cfl_kvlist_insert_int64(list, key, (int64_t) index) != 0) {
+            cfl_arena_destroy(arena);
+            return -1;
+        }
+    }
+    *reserved = cfl_arena_bytes_reserved(arena);
+    *used = cfl_arena_bytes_used(arena);
+    cfl_arena_destroy(arena);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    const char *mode;
+    size_t iterations;
+    size_t entries;
+    size_t chunk_size;
+    size_t iteration;
+    size_t reserved;
+    size_t used;
+    uint64_t start;
+    uint64_t elapsed;
+#if !defined(CFL_SYSTEM_WINDOWS)
+    struct rusage usage;
+#endif
+#if defined(__GLIBC__)
+    struct mallinfo2 memory;
+#endif
+
+    mode = argc > 1 ? argv[1] : "heap";
+    iterations = argc > 2 ? strtoull(argv[2], NULL, 10) : 1000;
+    entries = argc > 3 ? strtoull(argv[3], NULL, 10) : 1000;
+    chunk_size = argc > 4 ? strtoull(argv[4], NULL, 10) : 8192;
+    reserved = 0;
+    used = 0;
+
+    start = monotonic_nanoseconds();
+    for (iteration = 0; iteration < iterations; iteration++) {
+        if (strcmp(mode, "arena") == 0) {
+            if (build_arena(entries, chunk_size, &reserved, &used) != 0) {
+                return EXIT_FAILURE;
+            }
+        }
+        else if (strcmp(mode, "heap") == 0) {
+            if (build_heap(entries) != 0) {
+                return EXIT_FAILURE;
+            }
+        }
+        else {
+            fprintf(stderr, "usage: %s heap|arena [iterations] [entries] [chunk-size]\n",
+                    argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+    elapsed = monotonic_nanoseconds() - start;
+
+    printf("mode=%s iterations=%zu entries=%zu elapsed_ns=%llu ns_per_entry=%.2f",
+           mode, iterations, entries, (unsigned long long) elapsed,
+           (double) elapsed / (double) (iterations * entries));
+#if !defined(CFL_SYSTEM_WINDOWS)
+    getrusage(RUSAGE_SELF, &usage);
+    printf(" max_rss_kb=%ld", usage.ru_maxrss);
+#endif
+#if defined(__GLIBC__)
+    memory = mallinfo2();
+    printf(" heap_in_use=%zu heap_free=%zu", (size_t) memory.uordblks,
+           (size_t) memory.fordblks);
+#endif
+    if (strcmp(mode, "arena") == 0) {
+        printf(" arena_reserved=%zu arena_used=%zu arena_slack=%zu",
+               reserved, used, reserved - used);
+    }
+    putchar('\n');
+    return EXIT_SUCCESS;
+}

--- a/benchmarks/run_variant_matrix.sh
+++ b/benchmarks/run_variant_matrix.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+build_dir=${1:-build-bench}
+benchmark="$build_dir/benchmarks/cfl-benchmark-variant-mutable"
+iterations=${CFL_MATRIX_ITERATIONS:-20}
+records=${CFL_MATRIX_RECORDS:-100}
+
+if [ ! -x "$benchmark" ]; then
+    echo "benchmark not found: $benchmark" >&2
+    exit 1
+fi
+
+echo "matrix_version=1 iterations=$iterations records=$records"
+
+for content_size in 0 65536 2097152; do
+    distributions="uniform bimodal heavy random"
+    if [ "$content_size" -eq 0 ]; then
+        distributions="uniform"
+    fi
+
+    for distribution in $distributions; do
+        for mutation_rounds in 0 10; do
+            "$benchmark" heap "$iterations" "$records" \
+                "$mutation_rounds" 8192 "$content_size" 0 "$distribution"
+
+            for chunk_size in 4096 8192 32768; do
+                for threshold in 0 1024 4096 16384 1073741824; do
+                    "$benchmark" arena "$iterations" "$records" \
+                        "$mutation_rounds" "$chunk_size" "$content_size" \
+                        "$threshold" "$distribution"
+                done
+            done
+        done
+    done
+done

--- a/benchmarks/summarize_variant_matrix.awk
+++ b/benchmarks/summarize_variant_matrix.awk
@@ -1,0 +1,41 @@
+function value(field, parts)
+{
+    split(field, parts, "=")
+    return parts[2] + 0
+}
+
+function text_value(field, parts)
+{
+    split(field, parts, "=")
+    return parts[2]
+}
+
+$1 == "mode=heap" {
+    key = text_value($2) "/" value($5) "/" value($6)
+    heap_time[key] = value($10)
+    heap_rss[key] = value($11)
+}
+
+$1 == "mode=arena" && value($7) == 8192 && value($8) == 0 {
+    key = text_value($2) "/" value($5) "/" value($6)
+    cpu_ratio = value($10) / heap_time[key]
+    rss_ratio = value($11) / heap_rss[key]
+    case_count++
+    cpu_ratio_sum += cpu_ratio
+    rss_ratio_sum += rss_ratio
+    if (cpu_ratio < 1.0) {
+        cpu_wins++
+    }
+    if (rss_ratio <= 1.0) {
+        rss_nonregressions++
+    }
+    printf("case=%s cpu_ratio=%.3f rss_ratio=%.3f\n",
+           key, cpu_ratio, rss_ratio)
+}
+
+END {
+    printf("summary_cases=%d cpu_wins=%d rss_nonregressions=%d " \
+           "mean_cpu_ratio=%.3f mean_rss_ratio=%.3f\n",
+           case_count, cpu_wins, rss_nonregressions,
+           cpu_ratio_sum / case_count, rss_ratio_sum / case_count)
+}

--- a/benchmarks/variant_mutable.c
+++ b/benchmarks/variant_mutable.c
@@ -1,0 +1,388 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+#if !defined(CFL_SYSTEM_WINDOWS)
+#include <sys/resource.h>
+#endif
+
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
+#include <cfl/cfl.h>
+
+struct otlp_document {
+    struct cfl_variant *root;
+    struct cfl_array *log_records;
+};
+
+static size_t record_payload_size(const char *distribution,
+                                  size_t total_size, size_t record_count,
+                                  size_t index)
+{
+    size_t large_count;
+    size_t small_count;
+    size_t small_size;
+    size_t remaining;
+    size_t weight;
+
+    if (record_count == 0 || total_size == 0) {
+        return 0;
+    }
+    index %= record_count;
+    if (strcmp(distribution, "bimodal") == 0) {
+        large_count = (record_count + 9) / 10;
+        small_count = record_count - large_count;
+        small_size = total_size / record_count;
+        if (small_size > 128) {
+            small_size = 128;
+        }
+        if (index % 10 != 0) {
+            return small_size;
+        }
+        remaining = total_size - (small_size * small_count);
+        return remaining / large_count;
+    }
+    if (strcmp(distribution, "heavy") == 0) {
+        if (record_count == 1 || index == 0) {
+            return total_size / 2;
+        }
+        return (total_size - (total_size / 2)) / (record_count - 1);
+    }
+    if (strcmp(distribution, "random") == 0) {
+        weight = ((index * 1103515245U + 12345U) >> 16) % 31 + 1;
+        return (total_size / record_count) * weight / 16;
+    }
+    return total_size / record_count;
+}
+
+static uint64_t wall_nanoseconds(void)
+{
+    struct timespec now;
+
+    timespec_get(&now, TIME_UTC);
+    return ((uint64_t) now.tv_sec * 1000000000ULL) + now.tv_nsec;
+}
+
+static struct cfl_kvlist *create_record(struct cfl_arena *arena,
+                                        size_t sequence,
+                                        char *payload, size_t payload_size)
+{
+    struct cfl_kvlist *record;
+    struct cfl_kvlist *body;
+    struct cfl_kvlist *attributes;
+    char message[64];
+
+    record = cfl_kvlist_create_in(arena);
+    body = cfl_kvlist_create_in(arena);
+    attributes = cfl_kvlist_create_in(arena);
+    if (record == NULL || body == NULL || attributes == NULL) {
+        return NULL;
+    }
+
+    snprintf(message, sizeof(message), "request completed sequence=%zu", sequence);
+    if (cfl_kvlist_insert_uint64(record, "timeUnixNano", sequence) != 0 ||
+        cfl_kvlist_insert_string(record, "severityText", "INFO") != 0 ||
+        (payload_size == 0 &&
+         cfl_kvlist_insert_string(body, "stringValue", message) != 0) ||
+        (payload_size > 0 &&
+         cfl_kvlist_insert_string_s(body, "stringValue", 11, payload,
+                                    payload_size, CFL_FALSE) != 0) ||
+        cfl_kvlist_insert_kvlist(record, "body", body) != 0 ||
+        cfl_kvlist_insert_string(attributes, "service.name", "api") != 0 ||
+        cfl_kvlist_insert_int64(attributes, "http.status_code", 200) != 0 ||
+        cfl_kvlist_insert_kvlist(record, "attributes", attributes) != 0) {
+        return NULL;
+    }
+
+    return record;
+}
+
+static int create_document(struct cfl_arena *arena, size_t record_count,
+                           char *payload, size_t content_size,
+                           const char *distribution,
+                           struct otlp_document *document)
+{
+    struct cfl_kvlist *root;
+    struct cfl_kvlist *resource_log;
+    struct cfl_kvlist *resource;
+    struct cfl_kvlist *scope_log;
+    struct cfl_kvlist *scope;
+    struct cfl_kvlist *record;
+    struct cfl_array *resource_logs;
+    struct cfl_array *scope_logs;
+    struct cfl_array *log_records;
+    size_t index;
+
+    root = cfl_kvlist_create_in(arena);
+    resource_log = cfl_kvlist_create_in(arena);
+    resource = cfl_kvlist_create_in(arena);
+    scope_log = cfl_kvlist_create_in(arena);
+    scope = cfl_kvlist_create_in(arena);
+    resource_logs = cfl_array_create_in(arena, 1);
+    scope_logs = cfl_array_create_in(arena, 1);
+    log_records = cfl_array_create_in(arena, record_count + 1);
+    if (root == NULL || resource_log == NULL || resource == NULL ||
+        scope_log == NULL || scope == NULL || resource_logs == NULL ||
+        scope_logs == NULL || log_records == NULL) {
+        return -1;
+    }
+
+    cfl_array_resizable(log_records, CFL_TRUE);
+    if (cfl_kvlist_insert_string(resource, "service.name", "checkout") != 0 ||
+        cfl_kvlist_insert_kvlist(resource_log, "resource", resource) != 0 ||
+        cfl_kvlist_insert_string(scope, "name", "benchmark.scope") != 0 ||
+        cfl_kvlist_insert_kvlist(scope_log, "scope", scope) != 0) {
+        return -1;
+    }
+
+    for (index = 0; index < record_count; index++) {
+        record = create_record(arena, index, payload,
+                               record_payload_size(distribution, content_size,
+                                                   record_count, index));
+        if (record == NULL || cfl_array_append_kvlist(log_records, record) != 0) {
+            return -1;
+        }
+    }
+
+    if (cfl_kvlist_insert_array(scope_log, "logRecords", log_records) != 0 ||
+        cfl_array_append_kvlist(scope_logs, scope_log) != 0 ||
+        cfl_kvlist_insert_array(resource_log, "scopeLogs", scope_logs) != 0 ||
+        cfl_array_append_kvlist(resource_logs, resource_log) != 0 ||
+        cfl_kvlist_insert_array(root, "resourceLogs", resource_logs) != 0) {
+        return -1;
+    }
+
+    document->root = cfl_variant_create_from_kvlist_in(arena, root);
+    document->log_records = log_records;
+    return document->root == NULL ? -1 : 0;
+}
+
+static int mutate_document(struct cfl_arena *arena,
+                           struct otlp_document *document,
+                           size_t mutation_round,
+                           char *payload, size_t content_size,
+                           const char *distribution)
+{
+    struct cfl_variant *record_variant;
+    struct cfl_variant *attributes_variant;
+    struct cfl_kvlist *record;
+    struct cfl_kvlist *attributes;
+    struct cfl_kvlist *new_record;
+    size_t index;
+    size_t payload_size;
+
+    for (index = 0; index < document->log_records->entry_count; index++) {
+        record_variant = document->log_records->entries[index];
+        record = record_variant->data.as_kvlist;
+        attributes_variant = cfl_kvlist_fetch(record, "attributes");
+        if (attributes_variant == NULL) {
+            return -1;
+        }
+        attributes = attributes_variant->data.as_kvlist;
+
+        cfl_kvlist_remove(record, "severityText");
+        cfl_kvlist_remove(attributes, "http.status_code");
+        if (cfl_kvlist_insert_string(record, "severityText",
+                                     mutation_round % 2 == 0 ? "WARN" : "INFO") != 0 ||
+            cfl_kvlist_insert_int64(attributes, "http.status_code",
+                                    mutation_round % 2 == 0 ? 503 : 200) != 0) {
+            return -1;
+        }
+    }
+
+    payload_size = record_payload_size(distribution, content_size,
+                                       document->log_records->entry_count,
+                                       mutation_round);
+    new_record = create_record(arena, mutation_round + 1000000,
+                               payload, payload_size);
+    if (new_record == NULL ||
+        cfl_array_append_kvlist(document->log_records, new_record) != 0 ||
+        cfl_array_remove_by_index(document->log_records, 0) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    const char *mode;
+    struct cfl_arena *arena;
+    struct otlp_document document;
+    size_t iterations;
+    size_t records;
+    size_t mutation_rounds;
+    size_t chunk_size;
+    size_t content_size;
+    size_t payload_size;
+    size_t large_object_threshold;
+    size_t external_cache_limit;
+    int external_cache_limit_set;
+    size_t iteration;
+    size_t round;
+    size_t reserved;
+    size_t used;
+    size_t initial_used;
+    size_t arena_cache_bytes;
+    size_t arena_cache_limit;
+    uint64_t start;
+    uint64_t elapsed;
+    double operation_count;
+    char *payload;
+    const char *distribution;
+#if !defined(CFL_SYSTEM_WINDOWS)
+    struct rusage usage;
+#endif
+#if defined(__GLIBC__)
+    struct mallinfo2 memory;
+    size_t heap_baseline;
+    size_t heap_initial_live;
+    size_t heap_final_live;
+#endif
+
+    mode = argc > 1 ? argv[1] : "heap";
+    iterations = argc > 2 ? strtoull(argv[2], NULL, 10) : 100;
+    records = argc > 3 ? strtoull(argv[3], NULL, 10) : 100;
+    mutation_rounds = argc > 4 ? strtoull(argv[4], NULL, 10) : 10;
+    chunk_size = argc > 5 ? strtoull(argv[5], NULL, 10) : 8192;
+    content_size = argc > 6 ? strtoull(argv[6], NULL, 10) : 0;
+    large_object_threshold = argc > 7 ? strtoull(argv[7], NULL, 10) : 0;
+    distribution = argc > 8 ? argv[8] : "uniform";
+    external_cache_limit_set = argc > 9;
+    external_cache_limit = external_cache_limit_set ?
+                           strtoull(argv[9], NULL, 10) : 0;
+    payload_size = content_size;
+    reserved = 0;
+    used = 0;
+    initial_used = 0;
+    arena_cache_bytes = 0;
+    arena_cache_limit = 0;
+    if (strcmp(mode, "heap") != 0 && strcmp(mode, "arena") != 0) {
+        fprintf(stderr, "usage: %s heap|arena [iterations] [records] "
+                        "[mutation-rounds] [chunk-size] [content-bytes] "
+                        "[large-object-threshold] [distribution] "
+                        "[external-cache-limit]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    payload = NULL;
+    if (payload_size > 0) {
+        payload = malloc(payload_size);
+        if (payload == NULL) {
+            return EXIT_FAILURE;
+        }
+        memset(payload, 'x', payload_size);
+    }
+
+#if defined(__GLIBC__)
+    memory = mallinfo2();
+    heap_baseline = (size_t) memory.uordblks;
+    heap_initial_live = 0;
+    heap_final_live = 0;
+#endif
+
+    arena = NULL;
+    if (strcmp(mode, "arena") == 0) {
+        arena = cfl_arena_create_ex(chunk_size,
+                                    large_object_threshold);
+        if (arena == NULL) {
+            return EXIT_FAILURE;
+        }
+        if (external_cache_limit_set) {
+            cfl_arena_external_cache_limit_set(arena,
+                                               external_cache_limit);
+        }
+    }
+
+    start = wall_nanoseconds();
+    for (iteration = 0; iteration < iterations; iteration++) {
+        if (create_document(arena, records, payload, content_size,
+                            distribution,
+                            &document) != 0) {
+            return EXIT_FAILURE;
+        }
+        if (arena != NULL) {
+            initial_used = cfl_arena_bytes_used(arena);
+        }
+#if defined(__GLIBC__)
+        else {
+            memory = mallinfo2();
+            heap_initial_live = (size_t) memory.uordblks - heap_baseline;
+        }
+#endif
+        for (round = 0; round < mutation_rounds; round++) {
+            if (mutate_document(arena, &document, round,
+                                payload, content_size, distribution) != 0) {
+                return EXIT_FAILURE;
+            }
+        }
+
+#if defined(__GLIBC__)
+        if (arena == NULL) {
+            memory = mallinfo2();
+            heap_final_live = (size_t) memory.uordblks - heap_baseline;
+        }
+#endif
+
+        if (arena == NULL) {
+            cfl_variant_destroy(document.root);
+        }
+        else {
+            reserved = cfl_arena_bytes_reserved(arena);
+            used = cfl_arena_bytes_used(arena);
+            arena_cache_bytes =
+                cfl_arena_external_cache_bytes(arena);
+            arena_cache_limit =
+                cfl_arena_external_cache_limit_get(arena);
+            if (iteration + 1 < iterations) {
+                cfl_arena_reset(arena);
+            }
+        }
+    }
+    elapsed = wall_nanoseconds() - start;
+    operation_count = (double) iterations * (double) records;
+    if (mutation_rounds > 0) {
+        operation_count *= (double) mutation_rounds;
+    }
+
+    if (arena != NULL) {
+        cfl_arena_destroy(arena);
+    }
+    printf("mode=%s distribution=%s iterations=%zu records=%zu "
+           "mutation_rounds=%zu content_bytes=%zu chunk_size=%zu threshold=%zu "
+           "elapsed_ns=%llu ns_per_operation=%.2f",
+           mode, distribution, iterations, records, mutation_rounds,
+           content_size, chunk_size, large_object_threshold,
+           (unsigned long long) elapsed,
+           (double) elapsed / operation_count);
+#if !defined(CFL_SYSTEM_WINDOWS)
+    getrusage(RUSAGE_SELF, &usage);
+    printf(" max_rss_kb=%ld", usage.ru_maxrss);
+#endif
+#if defined(__GLIBC__)
+    memory = mallinfo2();
+    if (strcmp(mode, "heap") == 0) {
+        printf(" heap_initial_live=%zu heap_final_live=%zu "
+               "heap_retained_after_destroy=%zu heap_free=%zu",
+               heap_initial_live, heap_final_live,
+               (size_t) memory.uordblks - heap_baseline,
+               (size_t) memory.fordblks);
+    }
+#endif
+    if (strcmp(mode, "arena") == 0) {
+        printf(" arena_reserved=%zu arena_initial_used=%zu arena_used=%zu "
+               "arena_mutation_growth=%zu arena_slack=%zu "
+               "arena_external_cache=%zu arena_external_cache_limit=%zu",
+               reserved, initial_used, used, used - initial_used,
+               reserved - used,
+               arena_cache_bytes, arena_cache_limit);
+    }
+    putchar('\n');
+    free(payload);
+    return EXIT_SUCCESS;
+}

--- a/include/cfl/cfl.h
+++ b/include/cfl/cfl.h
@@ -38,6 +38,7 @@
 #include <cfl/cfl_checksum.h>
 #include <cfl/cfl_time.h>
 #include <cfl/cfl_variant.h>
+#include <cfl/cfl_arena.h>
 #include <cfl/cfl_object.h>
 #include <cfl/cfl_utils.h>
 

--- a/include/cfl/cfl_arena.h
+++ b/include/cfl/cfl_arena.h
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef CFL_ARENA_H
+#define CFL_ARENA_H
+
+#include <stddef.h>
+
+struct cfl_arena;
+
+/*
+ * Arena-created objects remain valid until the arena is reset or destroyed.
+ * Reset and destroy invalidate every pointer allocated from the arena.
+ * Objects from different arenas, including heap-backed objects, cannot be
+ * attached to the same array or kvlist.
+ * An arena is not thread-safe. Callers must serialize all operations that use
+ * the same arena, including allocation, mutation, reset, and destruction.
+ * The reserved byte count includes CFL's allocation headers, but not allocator
+ * implementation metadata. The used byte count is the live payload capacity.
+ */
+struct cfl_arena *cfl_arena_create(size_t chunk_size);
+struct cfl_arena *cfl_arena_create_ex(size_t chunk_size,
+                                      size_t large_object_threshold);
+void cfl_arena_destroy(struct cfl_arena *arena);
+void cfl_arena_reset(struct cfl_arena *arena);
+size_t cfl_arena_bytes_reserved(struct cfl_arena *arena);
+size_t cfl_arena_bytes_used(struct cfl_arena *arena);
+size_t cfl_arena_large_object_threshold(struct cfl_arena *arena);
+void cfl_arena_external_cache_limit_set(struct cfl_arena *arena,
+                                        size_t limit);
+size_t cfl_arena_external_cache_limit_get(struct cfl_arena *arena);
+size_t cfl_arena_external_cache_bytes(struct cfl_arena *arena);
+
+#endif

--- a/include/cfl/cfl_array.h
+++ b/include/cfl/cfl_array.h
@@ -27,6 +27,7 @@
 #include <cfl/cfl_variant.h>
 
 struct cfl_kvlist;
+struct cfl_arena;
 
 struct cfl_array {
     int                  resizable;
@@ -36,9 +37,14 @@ struct cfl_array {
     struct cfl_variant  *owner;
     struct cfl_array    *parent_array;
     struct cfl_kvlist   *parent_kvlist;
+    struct cfl_arena *arena;
 };
 
 struct cfl_array *cfl_array_create(size_t slot_count);
+struct cfl_array *cfl_array_create_in(struct cfl_arena *arena,
+                                      size_t slot_count);
+struct cfl_array *cfl_array_create_like(struct cfl_array *parent,
+                                        size_t slot_count);
 void cfl_array_destroy(struct cfl_array *array);
 
 static inline struct cfl_variant *cfl_array_fetch_by_index(struct cfl_array *array,

--- a/include/cfl/cfl_kvlist.h
+++ b/include/cfl/cfl_kvlist.h
@@ -29,11 +29,13 @@
 #include <cfl/cfl_variant.h>
 
 struct cfl_array;
+struct cfl_arena;
 
 struct cfl_kvpair {
     cfl_sds_t            key;    /* Key */
     struct cfl_variant   *val;   /* Value */
     struct cfl_list      _head;  /* Link to list cfl_kvlist->list */
+    struct cfl_arena *arena;
 };
 
 struct cfl_kvlist {
@@ -41,9 +43,12 @@ struct cfl_kvlist {
     struct cfl_variant *owner;
     struct cfl_array   *parent_array;
     struct cfl_kvlist  *parent_kvlist;
+    struct cfl_arena *arena;
 };
 
 struct cfl_kvlist *cfl_kvlist_create();
+struct cfl_kvlist *cfl_kvlist_create_in(struct cfl_arena *arena);
+struct cfl_kvlist *cfl_kvlist_create_like(struct cfl_kvlist *parent);
 void cfl_kvlist_destroy(struct cfl_kvlist *list);
 
 /*
@@ -144,6 +149,11 @@ int cfl_kvlist_contains(struct cfl_kvlist *kvlist, char *name);
 int cfl_kvlist_remove(struct cfl_kvlist *kvlist, char *name);
 void cfl_kvpair_destroy(struct cfl_kvpair *pair);
 struct cfl_variant *cfl_kvpair_take_value(struct cfl_kvpair *pair);
+int cfl_kvpair_key_set_s(struct cfl_kvpair *pair,
+                         char *key, size_t key_size);
+int cfl_kvlist_rename_s(struct cfl_kvlist *list,
+                        char *old_key, size_t old_key_size,
+                        char *new_key, size_t new_key_size);
 
 
 #endif

--- a/include/cfl/cfl_sds.h
+++ b/include/cfl/cfl_sds.h
@@ -29,10 +29,11 @@
 #include <string.h>
 #include <inttypes.h>
 #include <stdint.h>
+typedef char *cfl_sds_t;
+
+struct cfl_arena;
 
 #define CFL_SDS_HEADER_SIZE (sizeof(uint64_t) + sizeof(uint64_t))
-
-typedef char *cfl_sds_t;
 
 #pragma pack(push, 1)
 struct cfl_sds {
@@ -44,6 +45,8 @@ struct cfl_sds {
 
 #define CFL_SDS_HEADER(s)  ((struct cfl_sds *) (s - CFL_SDS_HEADER_SIZE))
 
+size_t cfl_sds_alloc(cfl_sds_t s);
+
 static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
 {
     struct cfl_sds *head;
@@ -53,7 +56,7 @@ static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
     }
 
     head = CFL_SDS_HEADER(s);
-    if (len > head->alloc) {
+    if (len > cfl_sds_alloc(s)) {
         return;
     }
 
@@ -62,10 +65,11 @@ static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
 }
 
 size_t cfl_sds_avail(cfl_sds_t s);
-size_t cfl_sds_alloc(cfl_sds_t s);
 cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len);
 size_t cfl_sds_len(cfl_sds_t s);
 cfl_sds_t cfl_sds_create_len(const char *str, int len);
+cfl_sds_t cfl_sds_create_len_in(struct cfl_arena *arena,
+                                const char *str, int len);
 cfl_sds_t cfl_sds_create(const char *str);
 void cfl_sds_destroy(cfl_sds_t s);
 cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len);

--- a/include/cfl/cfl_variant.h
+++ b/include/cfl/cfl_variant.h
@@ -41,6 +41,7 @@
 
 struct cfl_array;
 struct cfl_kvlist;
+struct cfl_arena;
 
 struct cfl_variant {
     int type;
@@ -70,6 +71,8 @@ struct cfl_variant {
         struct cfl_array *as_array;
         struct cfl_kvlist *as_kvlist;
     } data;
+
+    struct cfl_arena *arena;
 };
 
 int cfl_variant_print(FILE *fp, struct cfl_variant *val);
@@ -85,6 +88,31 @@ struct cfl_variant *cfl_variant_create_from_null();
 struct cfl_variant *cfl_variant_create_from_kvlist(struct cfl_kvlist *value);
 struct cfl_variant *cfl_variant_create_from_reference(void *value);
 struct cfl_variant *cfl_variant_create();
+struct cfl_variant *cfl_variant_create_in(struct cfl_arena *arena);
+struct cfl_variant *cfl_variant_create_from_string_in(struct cfl_arena *arena,
+                                                       char *value);
+struct cfl_variant *cfl_variant_create_from_string_s_in(struct cfl_arena *arena,
+                                                         char *value,
+                                                         size_t value_length,
+                                                         int referenced);
+struct cfl_variant *cfl_variant_create_from_bytes_in(struct cfl_arena *arena,
+                                                      char *value, size_t length,
+                                                      int referenced);
+struct cfl_variant *cfl_variant_create_from_bool_in(struct cfl_arena *arena,
+                                                     int value);
+struct cfl_variant *cfl_variant_create_from_int64_in(struct cfl_arena *arena,
+                                                      int64_t value);
+struct cfl_variant *cfl_variant_create_from_uint64_in(struct cfl_arena *arena,
+                                                       uint64_t value);
+struct cfl_variant *cfl_variant_create_from_double_in(struct cfl_arena *arena,
+                                                       double value);
+struct cfl_variant *cfl_variant_create_from_null_in(struct cfl_arena *arena);
+struct cfl_variant *cfl_variant_create_from_reference_in(struct cfl_arena *arena,
+                                                          void *value);
+struct cfl_variant *cfl_variant_create_from_array_in(struct cfl_arena *arena,
+                                                      struct cfl_array *value);
+struct cfl_variant *cfl_variant_create_from_kvlist_in(struct cfl_arena *arena,
+                                                       struct cfl_kvlist *value);
 
 void cfl_variant_destroy(struct cfl_variant *instance);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(src
   cfl_object.c
   cfl_array.c
   cfl_variant.c
+  cfl_arena.c
   cfl_container.c
   cfl_checksum.c
   cfl_utils.c

--- a/src/cfl_arena.c
+++ b/src/cfl_arena.c
@@ -1,0 +1,571 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <cfl/cfl_arena.h>
+
+#include "cfl_arena_internal.h"
+
+#define CFL_ARENA_DEFAULT_CHUNK_SIZE 8192
+#define CFL_ARENA_SDS_CLASS_COUNT 6
+#define CFL_ARENA_EXTERNAL_CLASS_COUNT 24
+#define CFL_ARENA_EXTERNAL_EXACT_CLASS UINT8_MAX
+
+union cfl_arena_max_align {
+    long double long_double_value;
+    void *pointer_value;
+    uint64_t uint64_value;
+};
+
+struct cfl_arena_alignment_probe {
+    char byte;
+    union cfl_arena_max_align value;
+};
+
+struct cfl_arena_chunk {
+    struct cfl_arena_chunk *next;
+    size_t capacity;
+    size_t used;
+    union cfl_arena_max_align alignment;
+    unsigned char data[];
+};
+
+struct cfl_arena_external {
+    struct cfl_arena_external *next;
+    struct cfl_arena_external *previous;
+    size_t size;
+    uint8_t allocation_class;
+    unsigned char data[];
+};
+
+struct cfl_arena {
+    struct cfl_arena_chunk *head;
+    struct cfl_arena_chunk *current;
+    struct cfl_arena_external *external;
+    struct cfl_arena_external *external_cache[CFL_ARENA_EXTERNAL_CLASS_COUNT];
+    struct cfl_arena_external *external_exact_cache;
+    size_t external_cache_count[CFL_ARENA_EXTERNAL_CLASS_COUNT];
+    size_t external_cache_bytes;
+    size_t external_cache_limit;
+    size_t chunk_size;
+    size_t bytes_reserved;
+    size_t bytes_used;
+    size_t large_object_threshold;
+    void *free_variants;
+    void *free_kvpairs;
+    void *free_sds[CFL_ARENA_SDS_CLASS_COUNT];
+};
+
+static void arena_chunks_destroy(struct cfl_arena *arena)
+{
+    struct cfl_arena_chunk *chunk;
+    struct cfl_arena_chunk *next;
+
+    chunk = arena->head;
+    while (chunk != NULL) {
+        next = chunk->next;
+        free(chunk);
+        chunk = next;
+    }
+
+    arena->head = NULL;
+    arena->current = NULL;
+    arena->bytes_reserved = 0;
+    arena->bytes_used = 0;
+}
+
+static void arena_external_destroy(struct cfl_arena *arena)
+{
+    struct cfl_arena_external *allocation;
+    struct cfl_arena_external *next;
+    size_t index;
+
+    allocation = arena->external;
+    while (allocation != NULL) {
+        next = allocation->next;
+        arena->bytes_reserved -= allocation->size +
+                                 sizeof(struct cfl_arena_external);
+        arena->bytes_used -= allocation->size;
+        free(allocation);
+        allocation = next;
+    }
+    arena->external = NULL;
+
+    for (index = 0; index < CFL_ARENA_EXTERNAL_CLASS_COUNT; index++) {
+        allocation = arena->external_cache[index];
+        while (allocation != NULL) {
+            next = allocation->next;
+            arena->bytes_reserved -= allocation->size +
+                                     sizeof(struct cfl_arena_external);
+            free(allocation);
+            allocation = next;
+        }
+        arena->external_cache[index] = NULL;
+        arena->external_cache_count[index] = 0;
+    }
+    arena->external_cache_bytes = 0;
+
+    allocation = arena->external_exact_cache;
+    while (allocation != NULL) {
+        next = allocation->next;
+        arena->bytes_reserved -= allocation->size +
+                                 sizeof(struct cfl_arena_external);
+        free(allocation);
+        allocation = next;
+    }
+    arena->external_exact_cache = NULL;
+}
+
+struct cfl_arena *cfl_arena_create(size_t chunk_size)
+{
+    return cfl_arena_create_ex(chunk_size, 0);
+}
+
+struct cfl_arena *cfl_arena_create_ex(size_t chunk_size,
+                                      size_t large_object_threshold)
+{
+    struct cfl_arena *arena;
+
+    if (chunk_size == 0) {
+        chunk_size = CFL_ARENA_DEFAULT_CHUNK_SIZE;
+    }
+
+    arena = calloc(1, sizeof(struct cfl_arena));
+    if (arena == NULL) {
+        return NULL;
+    }
+
+    arena->chunk_size = chunk_size;
+    if (large_object_threshold == 0) {
+        large_object_threshold = chunk_size / 2;
+        if (large_object_threshold == 0) {
+            large_object_threshold = 1;
+        }
+    }
+    arena->large_object_threshold = large_object_threshold;
+    if (chunk_size <= SIZE_MAX / 256) {
+        arena->external_cache_limit = chunk_size * 256;
+    }
+    else {
+        arena->external_cache_limit = SIZE_MAX;
+    }
+    return arena;
+}
+
+void cfl_arena_destroy(struct cfl_arena *arena)
+{
+    if (arena == NULL) {
+        return;
+    }
+
+    arena_external_destroy(arena);
+    arena_chunks_destroy(arena);
+    free(arena);
+}
+
+void cfl_arena_reset(struct cfl_arena *arena)
+{
+    struct cfl_arena_chunk *chunk;
+    struct cfl_arena_external *allocation;
+    struct cfl_arena_external *next;
+
+    if (arena == NULL) {
+        return;
+    }
+
+    allocation = arena->external;
+    while (allocation != NULL) {
+        next = allocation->next;
+        cfl_arena_free_external(arena, allocation->data);
+        allocation = next;
+    }
+
+    chunk = arena->head;
+    while (chunk != NULL) {
+        chunk->used = 0;
+        chunk = chunk->next;
+    }
+
+    arena->bytes_used = 0;
+    arena->current = arena->head;
+    arena->free_variants = NULL;
+    arena->free_kvpairs = NULL;
+    memset(arena->free_sds, 0, sizeof(arena->free_sds));
+}
+
+void *cfl_arena_alloc(struct cfl_arena *arena, size_t size)
+{
+    struct cfl_arena_chunk *chunk;
+    size_t alignment;
+    size_t offset;
+    size_t remainder;
+    size_t capacity;
+    void *result;
+
+    if (arena == NULL || size == 0) {
+        return NULL;
+    }
+
+    alignment = offsetof(struct cfl_arena_alignment_probe, value);
+    chunk = arena->current;
+    while (chunk != NULL) {
+        offset = chunk->used;
+        remainder = offset % alignment;
+        if (remainder != 0) {
+            if (offset > SIZE_MAX - (alignment - remainder)) {
+                return NULL;
+            }
+            offset += alignment - remainder;
+        }
+        if (offset <= chunk->capacity && size <= chunk->capacity - offset) {
+            result = &chunk->data[offset];
+            chunk->used = offset + size;
+            arena->current = chunk;
+            arena->bytes_used += size;
+            return result;
+        }
+        chunk = chunk->next;
+    }
+
+    capacity = arena->chunk_size;
+    if (capacity < size) {
+        capacity = size;
+    }
+    if (capacity > SIZE_MAX - sizeof(struct cfl_arena_chunk)) {
+        return NULL;
+    }
+
+    chunk = malloc(sizeof(struct cfl_arena_chunk) + capacity);
+    if (chunk == NULL) {
+        return NULL;
+    }
+
+    chunk->next = arena->head;
+    chunk->capacity = capacity;
+    chunk->used = size;
+    arena->head = chunk;
+    arena->current = chunk;
+    arena->bytes_reserved += capacity +
+                             sizeof(struct cfl_arena_chunk);
+    arena->bytes_used += size;
+
+    return chunk->data;
+}
+
+void *cfl_arena_calloc(struct cfl_arena *arena,
+                       size_t count, size_t size)
+{
+    void *result;
+    size_t total;
+
+    if (count != 0 && size > SIZE_MAX / count) {
+        return NULL;
+    }
+
+    total = count * size;
+    result = cfl_arena_alloc(arena, total);
+    if (result != NULL) {
+        memset(result, 0, total);
+    }
+
+    return result;
+}
+
+size_t cfl_arena_bytes_reserved(struct cfl_arena *arena)
+{
+    return arena == NULL ? 0 : arena->bytes_reserved;
+}
+
+size_t cfl_arena_bytes_used(struct cfl_arena *arena)
+{
+    return arena == NULL ? 0 : arena->bytes_used;
+}
+
+size_t cfl_arena_large_object_threshold(struct cfl_arena *arena)
+{
+    return arena == NULL ? 0 : arena->large_object_threshold;
+}
+
+void cfl_arena_external_cache_limit_set(struct cfl_arena *arena,
+                                        size_t limit)
+{
+    struct cfl_arena_external *allocation;
+    size_t index;
+
+    if (arena == NULL) {
+        return;
+    }
+
+    arena->external_cache_limit = limit;
+    for (index = CFL_ARENA_EXTERNAL_CLASS_COUNT;
+         index > 0 && arena->external_cache_bytes > limit;
+         index--) {
+        while (arena->external_cache[index - 1] != NULL &&
+               arena->external_cache_bytes > limit) {
+            allocation = arena->external_cache[index - 1];
+            arena->external_cache[index - 1] = allocation->next;
+            arena->external_cache_count[index - 1]--;
+            arena->external_cache_bytes -= allocation->size;
+            arena->bytes_reserved -= allocation->size +
+                                     sizeof(struct cfl_arena_external);
+            free(allocation);
+        }
+    }
+
+    while (arena->external_exact_cache != NULL &&
+           arena->external_cache_bytes > limit) {
+        allocation = arena->external_exact_cache;
+        arena->external_exact_cache = allocation->next;
+        arena->external_cache_bytes -= allocation->size;
+        arena->bytes_reserved -= allocation->size +
+                                 sizeof(struct cfl_arena_external);
+        free(allocation);
+    }
+}
+
+size_t cfl_arena_external_cache_limit_get(struct cfl_arena *arena)
+{
+    return arena == NULL ? 0 : arena->external_cache_limit;
+}
+
+size_t cfl_arena_external_cache_bytes(struct cfl_arena *arena)
+{
+    return arena == NULL ? 0 : arena->external_cache_bytes;
+}
+
+void *cfl_arena_alloc_external(struct cfl_arena *arena,
+                               size_t size)
+{
+    static const size_t class_sizes[CFL_ARENA_EXTERNAL_CLASS_COUNT] = {
+        4096, 6144, 8192, 12288, 16384, 24576,
+        32768, 49152, 65536, 98304, 131072, 196608,
+        262144, 327680, 393216, 458752, 524288, 655360,
+        786432, 917504, 1048576, 1310720, 1572864, 2097152
+    };
+    struct cfl_arena_external *allocation;
+    struct cfl_arena_external *previous;
+    size_t allocation_size;
+    size_t index;
+    uint8_t allocation_class;
+
+    if (arena == NULL || size == 0 ||
+        size > SIZE_MAX - sizeof(struct cfl_arena_external)) {
+        return NULL;
+    }
+
+    allocation_class = 0;
+    allocation_size = size;
+    for (index = 0; index < CFL_ARENA_EXTERNAL_CLASS_COUNT; index++) {
+        if (size <= class_sizes[index]) {
+            allocation_class = (uint8_t) (index + 1);
+            allocation_size = class_sizes[index];
+            break;
+        }
+    }
+
+    if (allocation_class != 0 &&
+        allocation_size - size > size / 8) {
+        allocation_class = CFL_ARENA_EXTERNAL_EXACT_CLASS;
+        allocation_size = size;
+    }
+
+    allocation = NULL;
+    if (allocation_class == CFL_ARENA_EXTERNAL_EXACT_CLASS) {
+        previous = NULL;
+        allocation = arena->external_exact_cache;
+        while (allocation != NULL) {
+            if (allocation->size == allocation_size) {
+                if (previous == NULL) {
+                    arena->external_exact_cache = allocation->next;
+                }
+                else {
+                    previous->next = allocation->next;
+                }
+                arena->external_cache_bytes -= allocation->size;
+                break;
+            }
+            previous = allocation;
+            allocation = allocation->next;
+        }
+    }
+    else if (allocation_class != 0) {
+        index = allocation_class - 1;
+        allocation = arena->external_cache[index];
+        if (allocation != NULL) {
+            arena->external_cache[index] = allocation->next;
+            arena->external_cache_count[index]--;
+            arena->external_cache_bytes -= allocation->size;
+        }
+    }
+
+    if (allocation == NULL) {
+        allocation = malloc(sizeof(struct cfl_arena_external) +
+                            allocation_size);
+        if (allocation == NULL) {
+            return NULL;
+        }
+        allocation->size = allocation_size;
+        arena->bytes_reserved += allocation_size +
+                                 sizeof(struct cfl_arena_external);
+    }
+
+    allocation->next = arena->external;
+    allocation->previous = NULL;
+    if (arena->external != NULL) {
+        arena->external->previous = allocation;
+    }
+    allocation->allocation_class = allocation_class;
+    arena->external = allocation;
+    arena->bytes_used += allocation->size;
+    return allocation->data;
+}
+
+void cfl_arena_free_external(struct cfl_arena *arena,
+                             void *pointer)
+{
+    struct cfl_arena_external *allocation;
+    size_t index;
+
+    if (arena == NULL || pointer == NULL) {
+        return;
+    }
+
+    allocation = (struct cfl_arena_external *)
+                 ((unsigned char *) pointer -
+                  offsetof(struct cfl_arena_external, data));
+    if (allocation->previous == NULL) {
+        arena->external = allocation->next;
+    }
+    else {
+        allocation->previous->next = allocation->next;
+    }
+    if (allocation->next != NULL) {
+        allocation->next->previous = allocation->previous;
+    }
+    arena->bytes_used -= allocation->size;
+    if (allocation->allocation_class != 0 &&
+        allocation->size <= arena->external_cache_limit &&
+        arena->external_cache_bytes <= arena->external_cache_limit -
+                                       allocation->size) {
+        if (allocation->allocation_class ==
+            CFL_ARENA_EXTERNAL_EXACT_CLASS) {
+            allocation->next = arena->external_exact_cache;
+            arena->external_exact_cache = allocation;
+        }
+        else {
+            index = allocation->allocation_class - 1;
+            allocation->next = arena->external_cache[index];
+            arena->external_cache[index] = allocation;
+            arena->external_cache_count[index]++;
+        }
+        allocation->previous = NULL;
+        arena->external_cache_bytes += allocation->size;
+    }
+    else {
+        arena->bytes_reserved -= allocation->size +
+                                 sizeof(struct cfl_arena_external);
+        free(allocation);
+    }
+}
+
+static void *arena_reusable_alloc(struct cfl_arena *arena,
+                                  void **free_list, size_t size)
+{
+    void *result;
+
+    if (arena == NULL) {
+        return NULL;
+    }
+
+    if (*free_list != NULL) {
+        result = *free_list;
+        *free_list = *((void **) result);
+        arena->bytes_used += size;
+        memset(result, 0, size);
+        return result;
+    }
+
+    return cfl_arena_calloc(arena, 1, size);
+}
+
+static void arena_reusable_free(struct cfl_arena *arena,
+                                void **free_list, void *pointer, size_t size)
+{
+    if (arena == NULL || pointer == NULL) {
+        return;
+    }
+
+    *((void **) pointer) = *free_list;
+    *free_list = pointer;
+    arena->bytes_used -= size;
+}
+
+void *cfl_arena_alloc_variant(struct cfl_arena *arena,
+                              size_t size)
+{
+    return arena_reusable_alloc(arena, &arena->free_variants, size);
+}
+
+void cfl_arena_free_variant(struct cfl_arena *arena,
+                            void *pointer, size_t size)
+{
+    arena_reusable_free(arena, &arena->free_variants, pointer, size);
+}
+
+void *cfl_arena_alloc_kvpair(struct cfl_arena *arena,
+                             size_t size)
+{
+    return arena_reusable_alloc(arena, &arena->free_kvpairs, size);
+}
+
+void cfl_arena_free_kvpair(struct cfl_arena *arena,
+                           void *pointer, size_t size)
+{
+    arena_reusable_free(arena, &arena->free_kvpairs, pointer, size);
+}
+
+void *cfl_arena_alloc_sds(struct cfl_arena *arena,
+                          size_t payload_size, size_t overhead_size,
+                          uint8_t *allocation_class,
+                          size_t *payload_capacity)
+{
+    static const size_t class_sizes[CFL_ARENA_SDS_CLASS_COUNT] = {
+        32, 64, 128, 256, 512, 1024
+    };
+    size_t index;
+
+    if (arena == NULL || allocation_class == NULL || payload_capacity == NULL) {
+        return NULL;
+    }
+
+    for (index = 0; index < CFL_ARENA_SDS_CLASS_COUNT; index++) {
+        if (payload_size <= class_sizes[index]) {
+            *allocation_class = (uint8_t) (index + 1);
+            *payload_capacity = class_sizes[index];
+            return arena_reusable_alloc(arena, &arena->free_sds[index],
+                                        overhead_size + class_sizes[index] + 1);
+        }
+    }
+
+    *allocation_class = 0;
+    *payload_capacity = payload_size;
+    return NULL;
+}
+
+void cfl_arena_free_sds(struct cfl_arena *arena,
+                        void *pointer, uint8_t allocation_class,
+                        size_t allocation_size)
+{
+    size_t index;
+
+    if (allocation_class == 0 ||
+        allocation_class > CFL_ARENA_SDS_CLASS_COUNT) {
+        return;
+    }
+
+    index = allocation_class - 1;
+    arena_reusable_free(arena, &arena->free_sds[index], pointer,
+                        allocation_size);
+}

--- a/src/cfl_arena_internal.h
+++ b/src/cfl_arena_internal.h
@@ -1,0 +1,31 @@
+#ifndef CFL_ARENA_INTERNAL_H
+#define CFL_ARENA_INTERNAL_H
+
+#include <stddef.h>
+
+#include <cfl/cfl_arena.h>
+
+void *cfl_arena_alloc(struct cfl_arena *arena, size_t size);
+void *cfl_arena_calloc(struct cfl_arena *arena,
+                       size_t count, size_t size);
+void *cfl_arena_alloc_external(struct cfl_arena *arena,
+                               size_t size);
+void cfl_arena_free_external(struct cfl_arena *arena,
+                             void *pointer);
+void *cfl_arena_alloc_variant(struct cfl_arena *arena,
+                              size_t size);
+void cfl_arena_free_variant(struct cfl_arena *arena,
+                            void *pointer, size_t size);
+void *cfl_arena_alloc_kvpair(struct cfl_arena *arena,
+                             size_t size);
+void cfl_arena_free_kvpair(struct cfl_arena *arena,
+                           void *pointer, size_t size);
+void *cfl_arena_alloc_sds(struct cfl_arena *arena,
+                          size_t payload_size, size_t overhead_size,
+                          uint8_t *allocation_class,
+                          size_t *payload_capacity);
+void cfl_arena_free_sds(struct cfl_arena *arena,
+                        void *pointer, uint8_t allocation_class,
+                        size_t allocation_size);
+
+#endif

--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -24,13 +24,33 @@
 #include <stdint.h>
 
 #include <cfl/cfl_container.h>
+#include "cfl_arena_internal.h"
 
 struct cfl_array *cfl_array_create(size_t slot_count)
+{
+    return cfl_array_create_in(NULL, slot_count);
+}
+
+struct cfl_array *cfl_array_create_in(struct cfl_arena *arena,
+                                      size_t slot_count)
 {
     struct cfl_array *array;
     size_t alloc_count;
 
-    array = malloc(sizeof(struct cfl_array));
+    alloc_count = slot_count;
+    if (alloc_count == 0) {
+        alloc_count = 1;
+    }
+    if (alloc_count > SIZE_MAX / sizeof(void *)) {
+        return NULL;
+    }
+
+    if (arena == NULL) {
+        array = malloc(sizeof(struct cfl_array));
+    }
+    else {
+        array = cfl_arena_alloc(arena, sizeof(struct cfl_array));
+    }
     if (array == NULL) {
         cfl_errno();
         return NULL;
@@ -40,19 +60,18 @@ struct cfl_array *cfl_array_create(size_t slot_count)
     array->resizable = CFL_FALSE;
 
     /* allocate fixed number of entries */
-    alloc_count = slot_count;
-    if (alloc_count == 0) {
-        alloc_count = 1;
+    if (arena == NULL) {
+        array->entries = calloc(alloc_count, sizeof(void *));
     }
-    if (alloc_count > SIZE_MAX / sizeof(void *)) {
-        free(array);
-        return NULL;
+    else {
+        array->entries = cfl_arena_calloc(arena, alloc_count,
+                                                  sizeof(void *));
     }
-
-    array->entries = calloc(alloc_count, sizeof(void *));
     if (array->entries == NULL) {
         cfl_errno();
-        free(array);
+        if (arena == NULL) {
+            free(array);
+        }
         return NULL;
     }
 
@@ -61,8 +80,19 @@ struct cfl_array *cfl_array_create(size_t slot_count)
     array->owner = NULL;
     array->parent_array = NULL;
     array->parent_kvlist = NULL;
+    array->arena = arena;
 
     return array;
+}
+
+struct cfl_array *cfl_array_create_like(struct cfl_array *parent,
+                                        size_t slot_count)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    return cfl_array_create_in(parent->arena, slot_count);
 }
 
 void cfl_array_destroy(struct cfl_array *array)
@@ -80,9 +110,13 @@ void cfl_array_destroy(struct cfl_array *array)
             }
         }
 
-        free(array->entries);
+        if (array->arena == NULL) {
+            free(array->entries);
+        }
     }
-    free(array);
+    if (array->arena == NULL) {
+        free(array);
+    }
 }
 
 int cfl_array_resizable(struct cfl_array *array, int v)
@@ -155,6 +189,10 @@ int cfl_array_append(struct cfl_array *array,
         return -1;
     }
 
+    if (array->arena != value->arena) {
+        return -1;
+    }
+
     if (array->entry_count >= array->slot_count) {
         /*
          * if there is no more space but the caller allowed to resize
@@ -180,7 +218,16 @@ int cfl_array_append(struct cfl_array *array,
 
             new_size = (new_slot_count * sizeof(void *));
 
-            tmp = realloc(array->entries, new_size);
+            if (array->arena == NULL) {
+                tmp = realloc(array->entries, new_size);
+            }
+            else {
+                tmp = cfl_arena_alloc(array->arena, new_size);
+                if (tmp != NULL) {
+                    memcpy(tmp, array->entries,
+                           array->entry_count * sizeof(void *));
+                }
+            }
             if (!tmp) {
                 cfl_report_runtime_error();
                 return -1;
@@ -211,7 +258,8 @@ int cfl_array_append_string(struct cfl_array *array, char *value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_string(value);
+    value_instance = cfl_variant_create_from_string_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -231,7 +279,9 @@ int cfl_array_append_string_s(struct cfl_array *array, char *str, size_t str_len
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_string_s(str, str_len, referenced);
+    value_instance = cfl_variant_create_from_string_s_in(
+                         array == NULL ? NULL : array->arena, str,
+                                                          str_len, referenced);
     if (value_instance == NULL) {
         return -1;
     }
@@ -253,7 +303,9 @@ int cfl_array_append_bytes(struct cfl_array *array,
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_bytes(value, length, referenced);
+    value_instance = cfl_variant_create_from_bytes_in(
+                         array == NULL ? NULL : array->arena, value,
+                                                       length, referenced);
     if (value_instance == NULL) {
         return -1;
     }
@@ -274,7 +326,8 @@ int cfl_array_append_reference(struct cfl_array *array, void *value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_reference(value);
+    value_instance = cfl_variant_create_from_reference_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -296,7 +349,8 @@ int cfl_array_append_bool(struct cfl_array *array, int value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_bool(value);
+    value_instance = cfl_variant_create_from_bool_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -318,7 +372,8 @@ int cfl_array_append_int64(struct cfl_array *array, int64_t value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_int64(value);
+    value_instance = cfl_variant_create_from_int64_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -339,7 +394,8 @@ int cfl_array_append_uint64(struct cfl_array *array, uint64_t value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_uint64(value);
+    value_instance = cfl_variant_create_from_uint64_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -361,7 +417,8 @@ int cfl_array_append_double(struct cfl_array *array, double value)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_double(value);
+    value_instance = cfl_variant_create_from_double_in(
+                         array == NULL ? NULL : array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -383,7 +440,8 @@ int cfl_array_append_null(struct cfl_array *array)
     struct cfl_variant *value_instance;
     int                 result;
 
-    value_instance = cfl_variant_create_from_null();
+    value_instance = cfl_variant_create_from_null_in(
+                         array == NULL ? NULL : array->arena);
     if (value_instance == NULL) {
         return -1;
     }
@@ -410,7 +468,7 @@ int cfl_array_append_array(struct cfl_array *array, struct cfl_array *value)
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_array(value);
+    value_instance = cfl_variant_create_from_array_in(array->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -437,7 +495,7 @@ int cfl_array_append_new_array(struct cfl_array *array, size_t size)
         return -1;
     }
 
-    value = cfl_array_create(size);
+    value = cfl_array_create_in(array->arena, size);
 
     if (value == NULL) {
         return -1;
@@ -460,7 +518,7 @@ int cfl_array_append_kvlist(struct cfl_array *array, struct cfl_kvlist *value)
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_kvlist(value);
+    value_instance = cfl_variant_create_from_kvlist_in(array->arena, value);
     if (value_instance == NULL) {
         return -1;
     }

--- a/src/cfl_kvlist.c
+++ b/src/cfl_kvlist.c
@@ -21,6 +21,7 @@
 #include <cfl/cfl_kvlist.h>
 #include <cfl/cfl_array.h>
 #include <cfl/cfl_variant.h>
+#include "cfl_arena_internal.h"
 #include <cfl/cfl_compat.h>
 
 #include <limits.h>
@@ -86,9 +87,19 @@ static int print_json_string(FILE *fp, const char *str, size_t len)
 
 struct cfl_kvlist *cfl_kvlist_create()
 {
+    return cfl_kvlist_create_in(NULL);
+}
+
+struct cfl_kvlist *cfl_kvlist_create_in(struct cfl_arena *arena)
+{
     struct cfl_kvlist *list;
 
-    list = malloc(sizeof(struct cfl_kvlist));
+    if (arena == NULL) {
+        list = malloc(sizeof(struct cfl_kvlist));
+    }
+    else {
+        list = cfl_arena_alloc(arena, sizeof(struct cfl_kvlist));
+    }
     if (list == NULL) {
         cfl_report_runtime_error();
         return NULL;
@@ -98,8 +109,18 @@ struct cfl_kvlist *cfl_kvlist_create()
     list->owner = NULL;
     list->parent_array = NULL;
     list->parent_kvlist = NULL;
+    list->arena = arena;
 
     return list;
+}
+
+struct cfl_kvlist *cfl_kvlist_create_like(struct cfl_kvlist *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    return cfl_kvlist_create_in(parent->arena);
 }
 
 void cfl_kvlist_destroy(struct cfl_kvlist *list)
@@ -123,10 +144,18 @@ void cfl_kvlist_destroy(struct cfl_kvlist *list)
             cfl_variant_destroy(pair->val);
         }
         cfl_list_del(&pair->_head);
-        free(pair);
+        if (pair->arena == NULL) {
+            free(pair);
+        }
+        else {
+            cfl_arena_free_kvpair(pair->arena, pair,
+                                          sizeof(struct cfl_kvpair));
+        }
     }
 
-    free(list);
+    if (list->arena == NULL) {
+        free(list);
+    }
 }
 
 int cfl_kvlist_insert_string_s(struct cfl_kvlist *list,
@@ -141,7 +170,8 @@ int cfl_kvlist_insert_string_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_string_s(value, value_size, referenced);
+    value_instance = cfl_variant_create_from_string_s_in(list->arena, value,
+                                                          value_size, referenced);
     if (value_instance == NULL) {
         return -1;
     }
@@ -168,7 +198,8 @@ int cfl_kvlist_insert_bytes_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_bytes(value, length, referenced);
+    value_instance = cfl_variant_create_from_bytes_in(list->arena, value,
+                                                       length, referenced);
     if (value_instance == NULL) {
         return -1;
     }
@@ -193,7 +224,7 @@ int cfl_kvlist_insert_reference_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_reference(value);
+    value_instance = cfl_variant_create_from_reference_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -220,7 +251,7 @@ int cfl_kvlist_insert_bool_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_bool(value);
+    value_instance = cfl_variant_create_from_bool_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -247,7 +278,7 @@ int cfl_kvlist_insert_int64_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_int64(value);
+    value_instance = cfl_variant_create_from_int64_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -274,7 +305,7 @@ int cfl_kvlist_insert_uint64_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_uint64(value);
+    value_instance = cfl_variant_create_from_uint64_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -301,7 +332,7 @@ int cfl_kvlist_insert_double_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_double(value);
+    value_instance = cfl_variant_create_from_double_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -328,7 +359,7 @@ int cfl_kvlist_insert_array_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_array(value);
+    value_instance = cfl_variant_create_from_array_in(list->arena, value);
 
     if (value_instance == NULL) {
         return -1;
@@ -358,7 +389,7 @@ int cfl_kvlist_insert_new_array_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value = cfl_array_create(size);
+    value = cfl_array_create_in(list->arena, size);
 
     if (value == NULL) {
         return -1;
@@ -386,7 +417,7 @@ int cfl_kvlist_insert_kvlist_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    value_instance = cfl_variant_create_from_kvlist(value);
+    value_instance = cfl_variant_create_from_kvlist_in(list->arena, value);
     if (value_instance == NULL) {
         return -1;
     }
@@ -414,27 +445,50 @@ int cfl_kvlist_insert_s(struct cfl_kvlist *list,
         return -1;
     }
 
-    pair = malloc(sizeof(struct cfl_kvpair));
+    if (list->arena != value->arena) {
+        return -1;
+    }
+
+    if (list->arena == NULL) {
+        pair = malloc(sizeof(struct cfl_kvpair));
+    }
+    else {
+        pair = cfl_arena_alloc_kvpair(list->arena,
+                                              sizeof(struct cfl_kvpair));
+    }
     if (pair == NULL) {
         cfl_report_runtime_error();
         return -1;
     }
 
-    pair->key = cfl_sds_create_len(key, (int) key_size);
+    pair->key = cfl_sds_create_len_in(list->arena, key, (int) key_size);
     if (pair->key == NULL) {
-        free(pair);
+        if (list->arena == NULL) {
+            free(pair);
+        }
+        else {
+            cfl_arena_free_kvpair(list->arena, pair,
+                                          sizeof(struct cfl_kvpair));
+        }
 
         return -2;
     }
 
     if (cfl_container_move_variant_to_kvlist(list, value) != 0) {
         cfl_sds_destroy(pair->key);
-        free(pair);
+        if (list->arena == NULL) {
+            free(pair);
+        }
+        else {
+            cfl_arena_free_kvpair(list->arena, pair,
+                                          sizeof(struct cfl_kvpair));
+        }
 
         return -1;
     }
 
     pair->val = value;
+    pair->arena = list->arena;
 
     cfl_list_add(&pair->_head, &list->list);
     return 0;
@@ -739,7 +793,13 @@ void cfl_kvpair_destroy(struct cfl_kvpair *pair)
             cfl_variant_destroy(pair->val);
         }
 
-        free(pair);
+        if (pair->arena == NULL) {
+            free(pair);
+        }
+        else {
+            cfl_arena_free_kvpair(pair->arena, pair,
+                                          sizeof(struct cfl_kvpair));
+        }
     }
 }
 
@@ -757,4 +817,58 @@ struct cfl_variant *cfl_kvpair_take_value(struct cfl_kvpair *pair)
     cfl_container_release_variant(value);
 
     return value;
+}
+
+int cfl_kvpair_key_set_s(struct cfl_kvpair *pair,
+                         char *key, size_t key_size)
+{
+    cfl_sds_t replacement;
+
+    if (pair == NULL || key == NULL || key_size > INT_MAX) {
+        return -1;
+    }
+
+    replacement = cfl_sds_create_len_in(pair->arena, key, (int) key_size);
+    if (replacement == NULL) {
+        return -1;
+    }
+
+    cfl_sds_destroy(pair->key);
+    pair->key = replacement;
+    return 0;
+}
+
+int cfl_kvlist_rename_s(struct cfl_kvlist *list,
+                        char *old_key, size_t old_key_size,
+                        char *new_key, size_t new_key_size)
+{
+    struct cfl_list *head;
+    struct cfl_kvpair *pair;
+    struct cfl_kvpair *source;
+
+    if (list == NULL || old_key == NULL || new_key == NULL ||
+        old_key_size > INT_MAX || new_key_size > INT_MAX) {
+        return -1;
+    }
+
+    source = NULL;
+    cfl_list_foreach(head, &list->list) {
+        pair = cfl_list_entry(head, struct cfl_kvpair, _head);
+        if (cfl_sds_len(pair->key) == old_key_size &&
+            memcmp(pair->key, old_key, old_key_size) == 0) {
+            source = pair;
+        }
+        if (cfl_sds_len(pair->key) == new_key_size &&
+            memcmp(pair->key, new_key, new_key_size) == 0 &&
+            !(old_key_size == new_key_size &&
+              memcmp(old_key, new_key, old_key_size) == 0)) {
+            return -1;
+        }
+    }
+
+    if (source == NULL) {
+        return -1;
+    }
+
+    return cfl_kvpair_key_set_s(source, new_key, new_key_size);
 }

--- a/src/cfl_sds.c
+++ b/src/cfl_sds.c
@@ -31,6 +31,22 @@
 #include <stdint.h>
 
 #include <cfl/cfl_sds.h>
+#include "cfl_arena_internal.h"
+
+#define CFL_SDS_ARENA_FLAG (UINT64_C(1) << 63)
+#define CFL_SDS_ALLOC_MASK (~CFL_SDS_ARENA_FLAG)
+
+struct cfl_sds_arena_header {
+    struct cfl_arena *arena;
+    uint8_t external;
+    uint8_t allocation_class;
+};
+
+static struct cfl_sds_arena_header *sds_arena_header(struct cfl_sds *head)
+{
+    return (struct cfl_sds_arena_header *)
+           ((char *) head - sizeof(struct cfl_sds_arena_header));
+}
 
 size_t cfl_sds_avail(cfl_sds_t s)
 {
@@ -41,27 +57,71 @@ size_t cfl_sds_avail(cfl_sds_t s)
     }
 
     h = CFL_SDS_HEADER(s);
-    return (size_t) (h->alloc - h->len);
+    return (size_t) ((h->alloc & CFL_SDS_ALLOC_MASK) - h->len);
 }
 
-static cfl_sds_t sds_alloc(size_t size)
+static cfl_sds_t sds_alloc(struct cfl_arena *arena, size_t size)
 {
     void *buf;
     cfl_sds_t s;
     struct cfl_sds *head;
+    struct cfl_sds_arena_header *arena_head;
+    size_t allocation_size;
+    size_t external_threshold;
+    size_t payload_capacity;
+    uint8_t allocation_class;
 
-    if (size > SIZE_MAX - CFL_SDS_HEADER_SIZE - 1) {
+    if (size > SIZE_MAX - CFL_SDS_HEADER_SIZE -
+                         sizeof(struct cfl_sds_arena_header) - 1) {
         return NULL;
     }
 
-    buf = malloc(CFL_SDS_HEADER_SIZE + size + 1);
+    payload_capacity = size;
+    allocation_class = 0;
+    allocation_size = CFL_SDS_HEADER_SIZE + size + 1;
+    if (arena == NULL) {
+        buf = malloc(allocation_size);
+    }
+    else if (size <= 1024) {
+        external_threshold = cfl_arena_large_object_threshold(arena);
+        buf = cfl_arena_alloc_sds(arena, size,
+                                          CFL_SDS_HEADER_SIZE +
+                                          sizeof(struct cfl_sds_arena_header),
+                                          &allocation_class,
+                                          &payload_capacity);
+        allocation_size = sizeof(struct cfl_sds_arena_header) +
+                          CFL_SDS_HEADER_SIZE + payload_capacity + 1;
+    }
+    else {
+        external_threshold = cfl_arena_large_object_threshold(arena);
+        allocation_size += sizeof(struct cfl_sds_arena_header);
+        if (allocation_size >= external_threshold) {
+            buf = cfl_arena_alloc_external(arena, allocation_size);
+        }
+        else {
+            buf = cfl_arena_alloc(arena, allocation_size);
+        }
+    }
     if (!buf) {
         return NULL;
     }
 
-    head = buf;
+    if (arena == NULL) {
+        head = buf;
+    }
+    else {
+        arena_head = buf;
+        arena_head->arena = arena;
+        arena_head->external = allocation_class == 0 &&
+                               allocation_size >= external_threshold;
+        arena_head->allocation_class = allocation_class;
+        head = (struct cfl_sds *) (arena_head + 1);
+    }
     head->len = 0;
-    head->alloc = size;
+    head->alloc = payload_capacity;
+    if (arena != NULL) {
+        head->alloc |= CFL_SDS_ARENA_FLAG;
+    }
 
     s = head->buf;
     *s = '\0';
@@ -75,14 +135,16 @@ size_t cfl_sds_alloc(cfl_sds_t s)
         return 0;
     }
 
-    return (size_t) CFL_SDS_HEADER(s)->alloc;
+    return (size_t) (CFL_SDS_HEADER(s)->alloc & CFL_SDS_ALLOC_MASK);
 }
 
 cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len)
 {
     size_t new_size;
     struct cfl_sds *head;
+    struct cfl_sds *new_head;
     cfl_sds_t out;
+    cfl_sds_t arena_out;
     void *tmp;
 
     if (s == NULL) {
@@ -96,10 +158,6 @@ cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len)
         return s;
     }
 
-    if (head->alloc > UINT64_MAX - len) {
-        return NULL;
-    }
-
     if (cfl_sds_alloc(s) > SIZE_MAX - len) {
         return NULL;
     }
@@ -108,8 +166,19 @@ cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len)
     if (new_size > SIZE_MAX - CFL_SDS_HEADER_SIZE - 1) {
         return NULL;
     }
-    new_size += CFL_SDS_HEADER_SIZE + 1;
+    if ((head->alloc & CFL_SDS_ARENA_FLAG) != 0) {
+        arena_out = sds_alloc(sds_arena_header(head)->arena, new_size);
+        if (arena_out == NULL) {
+            return NULL;
+        }
+        memcpy(arena_out, s, head->len + 1);
+        new_head = CFL_SDS_HEADER(arena_out);
+        new_head->len = head->len;
+        cfl_sds_destroy(s);
+        return arena_out;
+    }
 
+    new_size += CFL_SDS_HEADER_SIZE + 1;
     tmp = realloc(head, new_size);
     if (!tmp) {
         return NULL;
@@ -132,6 +201,12 @@ size_t cfl_sds_len(cfl_sds_t s)
 
 cfl_sds_t cfl_sds_create_len(const char *str, int len)
 {
+    return cfl_sds_create_len_in(NULL, str, len);
+}
+
+cfl_sds_t cfl_sds_create_len_in(struct cfl_arena *arena,
+                                const char *str, int len)
+{
     cfl_sds_t s;
     struct cfl_sds *head;
 
@@ -139,7 +214,7 @@ cfl_sds_t cfl_sds_create_len(const char *str, int len)
         return NULL;
     }
 
-    s = sds_alloc(len);
+    s = sds_alloc(arena, len);
     if (!s) {
         return NULL;
     }
@@ -174,13 +249,29 @@ cfl_sds_t cfl_sds_create(const char *str)
 void cfl_sds_destroy(cfl_sds_t s)
 {
     struct cfl_sds *head;
+    struct cfl_sds_arena_header *arena_head;
 
     if (!s) {
         return;
     }
 
     head = CFL_SDS_HEADER(s);
-    free(head);
+    if ((head->alloc & CFL_SDS_ARENA_FLAG) == 0) {
+        free(head);
+    }
+    else {
+        arena_head = sds_arena_header(head);
+        if (arena_head->external) {
+            cfl_arena_free_external(arena_head->arena, arena_head);
+        }
+        else if (arena_head->allocation_class != 0) {
+            cfl_arena_free_sds(
+                arena_head->arena, arena_head,
+                arena_head->allocation_class,
+                sizeof(struct cfl_sds_arena_header) + CFL_SDS_HEADER_SIZE +
+                cfl_sds_alloc(s) + 1);
+        }
+    }
 }
 
 cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
@@ -194,6 +285,7 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
     cfl_sds_t tmp = NULL;
     const char *source;
     int source_in_buffer;
+    size_t allocation_size;
 
     if (s == NULL || str == NULL || len < 0) {
         return NULL;
@@ -205,7 +297,9 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
 
     append_len = (size_t) len;
     head = CFL_SDS_HEADER(s);
-    if (head->len > head->alloc || head->len > SIZE_MAX - append_len - 1) {
+    allocation_size = cfl_sds_alloc(s);
+    if (head->len > allocation_size ||
+        head->len > SIZE_MAX - append_len - 1) {
         return NULL;
     }
 
@@ -221,10 +315,10 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
     buffer_addr = (uintptr_t) s;
     source_addr = (uintptr_t) str;
     if (source_addr >= buffer_addr &&
-        (source_addr - buffer_addr) <= head->alloc) {
+        (source_addr - buffer_addr) <= allocation_size) {
         source_offset = (size_t) (source_addr - buffer_addr);
 
-        if (append_len - 1 >= head->alloc - source_offset) {
+        if (append_len - 1 >= allocation_size - source_offset) {
             return NULL;
         }
 
@@ -259,7 +353,7 @@ cfl_sds_t cfl_sds_cat(cfl_sds_t s, const char *str, int len)
 
 cfl_sds_t cfl_sds_create_size(size_t size)
 {
-    return sds_alloc(size);
+    return sds_alloc(NULL, size);
 }
 
 void cfl_sds_set_len(cfl_sds_t s, size_t len)
@@ -271,7 +365,7 @@ void cfl_sds_set_len(cfl_sds_t s, size_t len)
     }
 
     head = CFL_SDS_HEADER(s);
-    if (len > head->alloc) {
+    if (len > cfl_sds_alloc(s)) {
         return;
     }
 

--- a/src/cfl_variant.c
+++ b/src/cfl_variant.c
@@ -19,6 +19,24 @@
 
 #include <cfl/cfl.h>
 #include <cfl/cfl_variant.h>
+#include <cfl/cfl_arena.h>
+
+#include "cfl_arena_internal.h"
+
+static void variant_instance_release(struct cfl_variant *instance)
+{
+    if (instance == NULL) {
+        return;
+    }
+
+    if (instance->arena == NULL) {
+        free(instance);
+    }
+    else {
+        cfl_arena_free_variant(instance->arena, instance,
+                                       sizeof(struct cfl_variant));
+    }
+}
 #include <cfl/cfl_array.h>
 #include <cfl/cfl_kvlist.h>
 #include <cfl/cfl_container.h>
@@ -211,7 +229,8 @@ struct cfl_variant *cfl_variant_create_from_string_s(char *value, size_t value_s
             return NULL;
         }
 
-        instance->data.as_string = cfl_sds_create_len(value, (int) value_size);
+        instance->data.as_string = cfl_sds_create_len_in(NULL, value,
+                                                         (int) value_size);
         if (instance->data.as_string == NULL) {
             free(instance);
             return NULL;
@@ -393,7 +412,203 @@ struct cfl_variant *cfl_variant_create()
         return NULL;
     }
     instance->size = 0;
+    instance->arena = NULL;
 
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_in(struct cfl_arena *arena)
+{
+    struct cfl_variant *instance;
+
+    if (arena == NULL) {
+        return cfl_variant_create();
+    }
+
+    instance = cfl_arena_alloc_variant(arena,
+                                                sizeof(struct cfl_variant));
+    if (instance != NULL) {
+        instance->arena = arena;
+    }
+
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_string_s_in(struct cfl_arena *arena,
+                                                         char *value,
+                                                         size_t value_size,
+                                                         int referenced)
+{
+    struct cfl_variant *instance;
+
+    if (value == NULL && value_size > 0) {
+        return NULL;
+    }
+
+    instance = cfl_variant_create_in(arena);
+    if (instance == NULL) {
+        return NULL;
+    }
+
+    instance->referenced = referenced ? CFL_TRUE : CFL_FALSE;
+    if (referenced) {
+        instance->data.as_string = value;
+    }
+    else {
+        if (value_size > INT_MAX) {
+            variant_instance_release(instance);
+            return NULL;
+        }
+        instance->data.as_string = cfl_sds_create_len_in(arena, value,
+                                                         (int) value_size);
+        if (instance->data.as_string == NULL) {
+            variant_instance_release(instance);
+            return NULL;
+        }
+    }
+    instance->size = value_size;
+    instance->type = CFL_VARIANT_STRING;
+
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_string_in(struct cfl_arena *arena,
+                                                       char *value)
+{
+    if (value == NULL) {
+        return NULL;
+    }
+    return cfl_variant_create_from_string_s_in(arena, value, strlen(value), CFL_FALSE);
+}
+
+struct cfl_variant *cfl_variant_create_from_bytes_in(struct cfl_arena *arena,
+                                                      char *value, size_t length,
+                                                      int referenced)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_from_string_s_in(arena, value, length, referenced);
+    if (instance != NULL) {
+        instance->type = CFL_VARIANT_BYTES;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_bool_in(struct cfl_arena *arena,
+                                                     int value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->data.as_bool = value;
+        instance->type = CFL_VARIANT_BOOL;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_int64_in(struct cfl_arena *arena,
+                                                      int64_t value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->data.as_int64 = value;
+        instance->type = CFL_VARIANT_INT;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_uint64_in(struct cfl_arena *arena,
+                                                       uint64_t value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->data.as_uint64 = value;
+        instance->type = CFL_VARIANT_UINT;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_double_in(struct cfl_arena *arena,
+                                                       double value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->data.as_double = value;
+        instance->type = CFL_VARIANT_DOUBLE;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_null_in(struct cfl_arena *arena)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->type = CFL_VARIANT_NULL;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_reference_in(struct cfl_arena *arena,
+                                                          void *value)
+{
+    struct cfl_variant *instance;
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        instance->data.as_reference = value;
+        instance->type = CFL_VARIANT_REFERENCE;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_array_in(struct cfl_arena *arena,
+                                                      struct cfl_array *value)
+{
+    struct cfl_variant *instance;
+
+    if (value != NULL && value->arena != arena) {
+        return NULL;
+    }
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        if (value != NULL && cfl_container_claim_array(value, instance) != 0) {
+            variant_instance_release(instance);
+            return NULL;
+        }
+        instance->data.as_array = value;
+        instance->type = CFL_VARIANT_ARRAY;
+    }
+    return instance;
+}
+
+struct cfl_variant *cfl_variant_create_from_kvlist_in(struct cfl_arena *arena,
+                                                       struct cfl_kvlist *value)
+{
+    struct cfl_variant *instance;
+
+    if (value != NULL && value->arena != arena) {
+        return NULL;
+    }
+
+    instance = cfl_variant_create_in(arena);
+    if (instance != NULL) {
+        if (value != NULL && cfl_container_claim_kvlist(value, instance) != 0) {
+            variant_instance_release(instance);
+            return NULL;
+        }
+        instance->data.as_kvlist = value;
+        instance->type = CFL_VARIANT_KVLIST;
+    }
     return instance;
 }
 
@@ -418,7 +633,7 @@ void cfl_variant_destroy(struct cfl_variant *instance)
         cfl_kvlist_destroy(instance->data.as_kvlist);
     }
 
-    free(instance);
+    variant_instance_release(instance);
 }
 
 void cfl_variant_size_set(struct cfl_variant *var, size_t size)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TESTS_FILES
   hash.c
   list.c
   variant.c
+  arena.c
   object.c
   version.c
   utils.c
@@ -39,6 +40,7 @@ set(PUBLIC_HEADERS
   cfl_time.h
   cfl_utils.h
   cfl_variant.h
+  cfl_arena.h
   cfl_version.h
   )
 

--- a/tests/arena.c
+++ b/tests/arena.c
@@ -1,0 +1,354 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <cfl/cfl.h>
+#include <string.h>
+#include <limits.h>
+
+#include "cfl_tests_internal.h"
+
+union test_max_align {
+    long double long_double_value;
+    void *pointer_value;
+    uint64_t uint64_value;
+};
+
+struct test_alignment_probe {
+    char byte;
+    union test_max_align value;
+};
+
+static void arena_build_and_destroy(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_array *array;
+    struct cfl_kvlist *list;
+    struct cfl_variant *root;
+    int ret;
+
+    arena = cfl_arena_create(256);
+    TEST_CHECK(arena != NULL);
+
+    list = cfl_kvlist_create_in(arena);
+    TEST_CHECK(list != NULL);
+    ret = cfl_kvlist_insert_string(list, "name", "cfl");
+    TEST_CHECK(ret == 0);
+
+    array = cfl_array_create_in(arena, 2);
+    TEST_CHECK(array != NULL);
+    ret = cfl_array_append_int64(array, 42);
+    TEST_CHECK(ret == 0);
+    ret = cfl_kvlist_insert_array(list, "values", array);
+    TEST_CHECK(ret == 0);
+
+    root = cfl_variant_create_from_kvlist_in(arena, list);
+    TEST_CHECK(root != NULL);
+    TEST_CHECK(cfl_arena_bytes_used(arena) > 0);
+    TEST_CHECK(cfl_arena_bytes_reserved(arena) >=
+               cfl_arena_bytes_used(arena));
+
+    cfl_variant_destroy(root);
+    cfl_arena_destroy(arena);
+}
+
+static void arena_reset(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_array *array;
+
+    arena = cfl_arena_create(128);
+    TEST_CHECK(arena != NULL);
+    array = cfl_array_create_in(arena, 4);
+    TEST_CHECK(array != NULL);
+    TEST_CHECK(cfl_arena_bytes_reserved(arena) > 0);
+
+    cfl_arena_reset(arena);
+    TEST_CHECK(cfl_arena_bytes_reserved(arena) >= 128);
+    TEST_CHECK(cfl_arena_bytes_used(arena) == 0);
+    cfl_arena_destroy(arena);
+}
+
+static void reject_cross_arena_values(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_array *array;
+    struct cfl_variant *value;
+
+    arena = cfl_arena_create(128);
+    TEST_CHECK(arena != NULL);
+    array = cfl_array_create_in(arena, 1);
+    value = cfl_variant_create_from_int64(1);
+    TEST_CHECK(array != NULL && value != NULL);
+
+    TEST_CHECK(cfl_array_append(array, value) == -1);
+    cfl_variant_destroy(value);
+    cfl_arena_destroy(arena);
+}
+
+static void mutable_otlp_log_graph(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_kvlist *root;
+    struct cfl_kvlist *record;
+    struct cfl_kvlist *attributes;
+    struct cfl_array *records;
+    struct cfl_variant *root_variant;
+    struct cfl_variant *value;
+    size_t initial_used;
+    size_t final_used;
+    int round;
+
+    arena = cfl_arena_create(256);
+    TEST_CHECK(arena != NULL);
+    root = cfl_kvlist_create_in(arena);
+    record = cfl_kvlist_create_in(arena);
+    attributes = cfl_kvlist_create_in(arena);
+    records = cfl_array_create_in(arena, 1);
+    TEST_CHECK(root != NULL && record != NULL && attributes != NULL &&
+               records != NULL);
+
+    TEST_CHECK(cfl_kvlist_insert_string(record, "severityText", "INFO") == 0);
+    TEST_CHECK(cfl_kvlist_insert_int64(attributes, "http.status_code", 200) == 0);
+    TEST_CHECK(cfl_kvlist_insert_kvlist(record, "attributes", attributes) == 0);
+    TEST_CHECK(cfl_array_append_kvlist(records, record) == 0);
+    TEST_CHECK(cfl_kvlist_insert_array(root, "logRecords", records) == 0);
+    root_variant = cfl_variant_create_from_kvlist_in(arena, root);
+    TEST_CHECK(root_variant != NULL);
+    initial_used = cfl_arena_bytes_used(arena);
+
+    for (round = 0; round < 10; round++) {
+        TEST_CHECK(cfl_kvlist_remove(record, "severityText") == CFL_TRUE);
+        TEST_CHECK(cfl_kvlist_remove(attributes, "http.status_code") == CFL_TRUE);
+        TEST_CHECK(cfl_kvlist_insert_string(record, "severityText", "WARN") == 0);
+        TEST_CHECK(cfl_kvlist_insert_int64(attributes, "http.status_code", 503) == 0);
+    }
+
+    value = cfl_kvlist_fetch(record, "severityText");
+    TEST_CHECK(value != NULL);
+    TEST_CHECK(strcmp(value->data.as_string, "WARN") == 0);
+    value = cfl_kvlist_fetch(attributes, "http.status_code");
+    TEST_CHECK(value != NULL);
+    TEST_CHECK(value->data.as_int64 == 503);
+    TEST_CHECK(cfl_array_size(records) == 1);
+
+    final_used = cfl_arena_bytes_used(arena);
+    TEST_CHECK(final_used == initial_used);
+    cfl_variant_destroy(root_variant);
+    cfl_arena_destroy(arena);
+}
+
+static void reclaim_large_string_on_remove(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_kvlist *list;
+    char payload[8192];
+    size_t before_remove;
+    size_t after_remove;
+    size_t reserved_before_remove;
+    char *first_buffer;
+    struct cfl_variant *value;
+
+    memset(payload, 'x', sizeof(payload));
+    arena = cfl_arena_create_ex(1024, 4096);
+    list = cfl_kvlist_create_in(arena);
+    TEST_CHECK(arena != NULL && list != NULL);
+    TEST_CHECK(cfl_arena_large_object_threshold(arena) == 4096);
+    TEST_CHECK(cfl_kvlist_insert_string_s(list, "body", 4, payload,
+                                          sizeof(payload), CFL_FALSE) == 0);
+    value = cfl_kvlist_fetch(list, "body");
+    TEST_CHECK(value != NULL);
+    first_buffer = value->data.as_string;
+    before_remove = cfl_arena_bytes_used(arena);
+    reserved_before_remove = cfl_arena_bytes_reserved(arena);
+    TEST_CHECK(cfl_kvlist_remove(list, "body") == CFL_TRUE);
+    after_remove = cfl_arena_bytes_used(arena);
+    TEST_CHECK(before_remove - after_remove >= sizeof(payload));
+    TEST_CHECK(cfl_arena_bytes_reserved(arena) ==
+               reserved_before_remove);
+    TEST_CHECK(cfl_arena_external_cache_bytes(arena) >=
+               sizeof(payload));
+    TEST_CHECK(cfl_kvlist_insert_string_s(list, "body", 4, payload,
+                                          sizeof(payload), CFL_FALSE) == 0);
+    value = cfl_kvlist_fetch(list, "body");
+    TEST_CHECK(value != NULL);
+    TEST_CHECK(value->data.as_string == first_buffer);
+
+    TEST_CHECK(cfl_kvlist_remove(list, "body") == CFL_TRUE);
+    TEST_CHECK(cfl_arena_external_cache_bytes(arena) > 0);
+    cfl_arena_external_cache_limit_set(arena, 0);
+    TEST_CHECK(cfl_arena_external_cache_limit_get(arena) == 0);
+    TEST_CHECK(cfl_arena_external_cache_bytes(arena) == 0);
+    cfl_arena_destroy(arena);
+}
+
+static void reuse_variant_and_kvpair_slots(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_variant *first_variant;
+    struct cfl_variant *second_variant;
+    struct cfl_kvlist *list;
+    struct cfl_kvpair *first_pair;
+    struct cfl_kvpair *second_pair;
+
+    arena = cfl_arena_create(1024);
+    TEST_CHECK(arena != NULL);
+    first_variant = cfl_variant_create_from_int64_in(arena, 1);
+    TEST_CHECK(first_variant != NULL);
+    cfl_variant_destroy(first_variant);
+    second_variant = cfl_variant_create_from_int64_in(arena, 2);
+    TEST_CHECK(second_variant == first_variant);
+    cfl_variant_destroy(second_variant);
+
+    list = cfl_kvlist_create_in(arena);
+    TEST_CHECK(list != NULL);
+    TEST_CHECK(cfl_kvlist_insert_int64(list, "first", 1) == 0);
+    first_pair = cfl_list_entry_first(&list->list, struct cfl_kvpair, _head);
+    TEST_CHECK(cfl_kvlist_remove(list, "first") == CFL_TRUE);
+    TEST_CHECK(cfl_kvlist_insert_int64(list, "second", 2) == 0);
+    second_pair = cfl_list_entry_first(&list->list, struct cfl_kvpair, _head);
+    TEST_CHECK(second_pair == first_pair);
+    cfl_kvlist_destroy(list);
+    cfl_arena_destroy(arena);
+}
+
+static void create_like_and_rename(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_kvlist *parent;
+    struct cfl_kvlist *child;
+    struct cfl_array *array;
+    struct cfl_array *child_array;
+
+    arena = cfl_arena_create(1024);
+    parent = cfl_kvlist_create_in(arena);
+    child = cfl_kvlist_create_like(parent);
+    array = cfl_array_create_in(arena, 1);
+    child_array = cfl_array_create_like(array, 1);
+    TEST_CHECK(arena != NULL && parent != NULL && child != NULL);
+    TEST_CHECK(array != NULL && child_array != NULL);
+    TEST_CHECK(child->arena == arena && child_array->arena == arena);
+
+    TEST_CHECK(cfl_kvlist_insert_string(parent, "old", "value") == 0);
+    TEST_CHECK(cfl_kvlist_rename_s(parent, "old", 3, "new", 3) == 0);
+    TEST_CHECK(cfl_kvlist_fetch(parent, "old") == NULL);
+    TEST_CHECK(cfl_kvlist_fetch(parent, "new") != NULL);
+
+    cfl_array_destroy(child_array);
+    cfl_array_destroy(array);
+    cfl_kvlist_destroy(child);
+    cfl_kvlist_destroy(parent);
+    cfl_arena_destroy(arena);
+}
+
+static void reuse_sds_size_classes(void)
+{
+    static const size_t sizes[] = {1, 32, 33, 64, 65, 128,
+                                   129, 256, 257, 512, 513, 1024};
+    struct cfl_arena *arena;
+    cfl_sds_t first;
+    cfl_sds_t second;
+    cfl_sds_t grown;
+    char payload[1024];
+    size_t index;
+
+    memset(payload, 's', sizeof(payload));
+    arena = cfl_arena_create(8192);
+    TEST_CHECK(arena != NULL);
+
+    for (index = 0; index < sizeof(sizes) / sizeof(sizes[0]); index++) {
+        first = cfl_sds_create_len_in(arena, payload, (int) sizes[index]);
+        TEST_CHECK(first != NULL);
+        cfl_sds_destroy(first);
+        second = cfl_sds_create_len_in(arena, payload, (int) sizes[index]);
+        TEST_CHECK(second == first);
+        cfl_sds_destroy(second);
+    }
+
+    first = cfl_sds_create_len_in(arena, payload, 31);
+    TEST_CHECK(first != NULL);
+    TEST_CHECK(cfl_sds_alloc(first) == 32);
+    grown = cfl_sds_increase(first, 1);
+    TEST_CHECK(grown != NULL);
+    TEST_CHECK(cfl_sds_alloc(grown) == 64);
+    TEST_CHECK(cfl_sds_len(grown) == 31);
+    TEST_CHECK(memcmp(grown, payload, 31) == 0);
+
+    second = cfl_sds_create_len_in(arena, payload, 32);
+    TEST_CHECK(second == first);
+    cfl_sds_destroy(second);
+    cfl_sds_destroy(grown);
+    cfl_arena_destroy(arena);
+}
+
+static void bound_external_rounding_and_cache(void)
+{
+    struct cfl_arena *arena;
+    cfl_sds_t value;
+    char *payload;
+    size_t payload_size;
+    size_t used;
+
+    payload_size = 1024 * 1024;
+    payload = malloc(payload_size);
+    TEST_CHECK(payload != NULL);
+    memset(payload, 'x', payload_size);
+
+    arena = cfl_arena_create(8192);
+    TEST_CHECK(arena != NULL);
+    cfl_arena_external_cache_limit_set(arena, 1024 * 1024);
+
+    value = cfl_sds_create_len_in(arena, payload, (int) payload_size);
+    TEST_CHECK(value != NULL);
+    used = cfl_arena_bytes_used(arena);
+    TEST_CHECK(used <= payload_size + (payload_size / 4) + 4096);
+    cfl_sds_destroy(value);
+    TEST_CHECK(cfl_arena_external_cache_bytes(arena) <=
+               cfl_arena_external_cache_limit_get(arena));
+
+    cfl_arena_destroy(arena);
+    free(payload);
+}
+
+static void reclaim_failed_variant_construction(void)
+{
+    struct cfl_arena *arena;
+    struct cfl_array *array;
+    struct cfl_variant *value;
+    struct cfl_variant *reused;
+    size_t before_failure;
+    size_t after_failure;
+
+    arena = cfl_arena_create(1024);
+    TEST_CHECK(arena != NULL);
+    before_failure = cfl_arena_bytes_used(arena);
+    value = cfl_variant_create_from_string_s_in(arena, "x",
+                                                (size_t) INT_MAX + 1,
+                                                CFL_FALSE);
+    TEST_CHECK(value == NULL);
+    after_failure = cfl_arena_bytes_used(arena);
+    TEST_CHECK(after_failure == before_failure);
+
+    array = cfl_array_create_in(arena, SIZE_MAX);
+    TEST_CHECK(array == NULL);
+    TEST_CHECK(cfl_arena_bytes_used(arena) == after_failure);
+
+    reused = cfl_variant_create_from_int64_in(arena, 1);
+    TEST_CHECK(reused != NULL);
+    TEST_CHECK(((uintptr_t) reused %
+                offsetof(struct test_alignment_probe, value)) == 0);
+    cfl_variant_destroy(reused);
+    cfl_arena_destroy(arena);
+}
+
+TEST_LIST = {
+    {"arena_build_and_destroy", arena_build_and_destroy},
+    {"arena_reset", arena_reset},
+    {"reject_cross_arena_values", reject_cross_arena_values},
+    {"mutable_otlp_log_graph", mutable_otlp_log_graph},
+    {"reclaim_large_string_on_remove", reclaim_large_string_on_remove},
+    {"reuse_variant_and_kvpair_slots", reuse_variant_and_kvpair_slots},
+    {"create_like_and_rename", create_like_and_rename},
+    {"reuse_sds_size_classes", reuse_sds_size_classes},
+    {"bound_external_rounding_and_cache", bound_external_rounding_and_cache},
+    {"reclaim_failed_variant_construction", reclaim_failed_variant_construction},
+    {NULL, NULL}
+};

--- a/tests/sds.c
+++ b/tests/sds.c
@@ -18,7 +18,29 @@
  */
 
 #include <cfl/cfl.h>
+#include <stddef.h>
 #include "cfl_tests_internal.h"
+
+static void test_sds_header_compatibility()
+{
+    cfl_sds_t s;
+    struct cfl_sds *head;
+
+    TEST_CHECK(CFL_SDS_HEADER_SIZE == sizeof(uint64_t) * 2);
+    TEST_CHECK(offsetof(struct cfl_sds, buf) == CFL_SDS_HEADER_SIZE);
+
+    s = cfl_sds_create_size(64);
+    TEST_CHECK(s != NULL);
+    if (s == NULL) {
+        return;
+    }
+
+    head = CFL_SDS_HEADER(s);
+    TEST_CHECK(head->len == 0);
+    TEST_CHECK(head->alloc == 64);
+    TEST_CHECK(head->buf == s);
+    cfl_sds_destroy(s);
+}
 
 static void test_sds_usage()
 {
@@ -172,6 +194,7 @@ static void test_sds_in_buffer_slice_boundaries()
 }
 
 TEST_LIST = {
+    { "sds_header_compatibility", test_sds_header_compatibility},
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
     { "sds_invalid_inputs", test_sds_invalid_inputs},


### PR DESCRIPTION
## Summary

Add an optional arena allocator for allocation-heavy CFL object graphs while preserving the existing heap-backed API.

The new `cfl_arena` interface supports shared allocation and reset of variants, arrays, kvlists, kvpairs, and owned SDS strings. Arena-aware constructors are opt-in, and `create_like()` helpers preserve the allocator of nested containers during mutation.

The implementation includes reusable variant and kvpair slots, SDS size classes, separately tracked large allocations, bounded external-buffer caching, ownership validation, memory statistics, benchmarks, and lifecycle documentation.

## Motivation

Recursive CFL structures can require many independent allocations. Workloads that build, mutate, and discard a complete document or batch can reduce allocator traffic and fragmentation by sharing one allocation lifetime.

The arena remains optional because long-lived objects, individually evicted values, and graphs whose children move between owners do not necessarily benefit from arena allocation.

## Compatibility

- Existing constructors remain heap-backed.
- Arena allocation is enabled only through the new `_in` constructors.
- Heap-backed SDS values preserve their existing header and data layout.
- Arena reset or destruction invalidates every pointer allocated from that arena.
- Objects from different allocators cannot be attached to the same array or kvlist.
- The new arena fields in public container structures require bundled consumers to be rebuilt.

## Validation

- CFL normal test suite: 34/34 passed.
- CFL AddressSanitizer and UndefinedBehaviorSanitizer suite: 34/34 passed.
- Public-header self-containment tests passed.
- Arena tests passed under Valgrind.
- cmetrics normal and sanitizer suites passed; all test binaries passed Valgrind.
- ctraces normal and sanitizer suites passed; all test binaries passed Valgrind.
- Fluent Bit built with updated CFL, cmetrics, and ctraces sources.
- Focused Fluent Bit cmetrics, ctraces, OpenTelemetry, and processor tests passed.
- Strict Valgrind OTLP integration matrix: 22/22 passed.
- Release benchmark tools build successfully.
- `git diff --check` passes.

## Performance

The mutable OTLP-style benchmark with approximately 2 MiB of owned content measured a 25.6% to 35.3% CPU improvement across uniform, bimodal, heavy-tail, and randomized payload distributions. Peak RSS ranged from 240 KiB below to 128 KiB above the heap implementation, depending on retained reusable capacity.

The documentation describes the CPU-versus-retained-memory tradeoff and the ownership boundaries required before enabling arenas in downstream components.
