### PR TITLE
build: use CFL-specific filename macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,6 @@ if(NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()
 
-# Define __FILENAME__
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
-
-
-
 # timespec_get() support
 check_c_source_compiles("
   #include <time.h>

--- a/include/cfl/cfl_log.h
+++ b/include/cfl/cfl_log.h
@@ -24,11 +24,12 @@
 
 int cfl_report_runtime_error_impl(int errnum, char *file, int line);
 
-#ifdef __FILENAME__
-#define cfl_report_runtime_error() cfl_report_runtime_error_impl(errno, __FILENAME__, __LINE__)
-#else
-#define cfl_report_runtime_error() cfl_report_runtime_error_impl(errno, __FILE__, __LINE__)
+#ifndef CFL_FILENAME
+#define CFL_FILENAME __FILE__
 #endif
+
+#define cfl_report_runtime_error() \
+    cfl_report_runtime_error_impl(errno, CFL_FILENAME, __LINE__)
 
 #define cfl_errno() do {} while (0)
 


### PR DESCRIPTION
## Summary

Follow up on #54 by removing the redundant global `__FILENAME__=__FILE__` compiler definition and using a CFL-specific filename macro in the logging interface.

`CFL_FILENAME` defaults to `__FILE__`, so compiler path-remapping options such as `-ffile-prefix-map` work normally. Embedders can override the value without relying on the reserved `__FILENAME__` identifier or modifying global `CMAKE_C_FLAGS`.

## Impact

- Removes the remaining global filename compiler definition from CFL's build.
- Replaces the generic reserved identifier with `CFL_FILENAME`.
- Preserves the existing `cfl_report_runtime_error()` behavior.
- Keeps the change scoped to CFL; bundled and downstream repositories are unchanged.

## Validation

- CFL test suite: 34/34 passed.
- Public-header self-containment tests passed.
- Release build with `-ffile-prefix-map` passed.
- The resulting CFL archive contains no checkout path, `$(subst ...)`, or `$(abspath ...)` expression.
- `git diff --check` passed.
