### PR TITLE
sds: preserve input when printf growth fails

### DIFF
--- a/src/cfl_sds.c
+++ b/src/cfl_sds.c
@@ -416,12 +416,20 @@ cfl_sds_t cfl_sds_printf(cfl_sds_t *sds, const char *fmt, ...)
         va_end(ap);
 
         if (size < 0) {
+            s[base_len] = '\0';
             return NULL;
         }
 
         if ((size_t) size <= avail) {
             break;
         }
+
+        /*
+         * vsnprintf() writes a truncated result when the available space is
+         * insufficient. Restore the original SDS terminator before growing
+         * so an allocation failure leaves the input unchanged.
+         */
+        s[base_len] = '\0';
 
         growth = (size_t) size - avail;
         tmp = cfl_sds_increase(s, growth);

--- a/tests/sds.c
+++ b/tests/sds.c
@@ -72,6 +72,17 @@ static void test_sds_printf()
     TEST_CHECK(tmp == s);
     TEST_CHECK(cfl_sds_len(s) == len);
     cfl_sds_destroy(s);
+
+    s = cfl_sds_create("prefix");
+    TEST_CHECK(s != NULL);
+
+    tmp = cfl_sds_printf(&s, "-%s", str);
+    TEST_CHECK(tmp == s);
+    TEST_CHECK(cfl_sds_len(s) == strlen("prefix-") + strlen(str));
+    TEST_CHECK(strncmp(s, "prefix-", strlen("prefix-")) == 0);
+    TEST_CHECK(strcmp(s + strlen("prefix-"), str) == 0);
+
+    cfl_sds_destroy(s);
 }
 
 static void test_sds_invalid_inputs()


### PR DESCRIPTION
## Summary

Restore the original SDS terminator before `cfl_sds_printf()` attempts to
grow its buffer.

## Background

`vsnprintf()` writes a truncated result when the available capacity is
insufficient. If the subsequent allocation failed, `cfl_sds_printf()` returned
`NULL` while leaving bytes beyond the recorded SDS length modified and the
terminator invariant broken.

The original terminator is now restored before growth and on formatting
errors, so failure leaves the input SDS valid and unchanged from the caller's
perspective.

A regression test also covers appending formatted content to an existing
prefix while the SDS grows.

## Validation

- Focused SDS unit test
- Full test suite: 34/34 passed
- ASan/UBSan focused SDS test with leak detection
- `git diff --check`
