### PR TITLE
array: report missing reference on removal

### DIFF
--- a/src/cfl_array.c
+++ b/src/cfl_array.c
@@ -174,7 +174,7 @@ int cfl_array_remove_by_reference(struct cfl_array *array,
         }
     }
 
-    return 0;
+    return -1;
 }
 
 int cfl_array_append(struct cfl_array *array,

--- a/tests/array.c
+++ b/tests/array.c
@@ -497,6 +497,34 @@ static void remove_by_reference()
     cfl_array_destroy(arr);
 }
 
+static void remove_by_reference_not_found()
+{
+    int ret;
+    struct cfl_array *arr;
+    struct cfl_array *other;
+    struct cfl_variant *var;
+
+    arr = cfl_array_create(1);
+    TEST_CHECK(arr != NULL);
+
+    other = cfl_array_create(1);
+    TEST_CHECK(other != NULL);
+
+    ret = cfl_array_append_string(other, "test");
+    TEST_CHECK(ret == 0);
+
+    var = cfl_array_fetch_by_index(other, 0);
+    TEST_CHECK(var != NULL);
+
+    ret = cfl_array_remove_by_reference(arr, var);
+    TEST_CHECK(ret == -1);
+
+    TEST_CHECK(cfl_array_fetch_by_index(other, 0) == var);
+
+    cfl_array_destroy(other);
+    cfl_array_destroy(arr);
+}
+
 static void print_write_error()
 {
 #ifdef __linux__
@@ -585,6 +613,7 @@ TEST_LIST = {
     {"append_kvlist_rejects_cycles", append_kvlist_rejects_cycles},
     {"remove_by_index",     remove_by_index},
     {"remove_by_reference", remove_by_reference},
+    {"remove_by_reference_not_found", remove_by_reference_not_found},
     {"print_write_error",   print_write_error},
     {"null_inputs",         null_inputs},
     { 0 }


### PR DESCRIPTION
## Summary

Return `-1` from `cfl_array_remove_by_reference()` when the supplied variant is not present in the array.

Add unit coverage using a variant owned by a different array and verify that the failed removal leaves it unchanged.

## Rationale

The previous implementation returned `0` both when an element was removed and when no matching reference existed. Reporting the missing reference as an error makes the result meaningful and aligns it with `cfl_array_remove_by_index()` for an invalid position.

No production callers were found in CFL, cmetrics, ctraces, or Fluent Bit.

## Validation

- `ctest --test-dir build-array-remove -R cfl-test-array --output-on-failure`
- `ctest --test-dir build-array-remove --output-on-failure` (34/34 passed)
- `git diff --check`